### PR TITLE
added vartype='member' to BgpPolicyRule:action_community_argument

### DIFF
--- a/pandevice/network.py
+++ b/pandevice/network.py
@@ -3200,6 +3200,7 @@ class BgpPolicyRule(BgpPolicyFilter):
                     "action_community_type": ["remove-regex", "append", "overwrite"],
                 },
                 path="action/{action}/update/community/{action_community_type}",
+                vartype="member",
             )
         )
         params.append(


### PR DESCRIPTION
added vartype='member' to the BgpPolicyRule class parameter 'action_community_argument' in network.py

## Description

I changed the vartype to "member" in order to correctly parse a template with the BgpPolicyRule action_community set to append and an argument of 65100:1

## Motivation and Context

I was unable to make any changes to the BGP configuration of the virtual-router because our template had an community_action set to append with an argument of 65100:1. Whenever I tried to make a change to certain sections of config under the virtual-router I would receive an error.

## How Has This Been Tested?

I am now able to successfully parse and change the virtual-router section of the templates in question without errors

## Screenshots (if appropriate)

<!--- Drag any screenshots here -->

## Types of changes

changes the way the BgpPolicyRule community_action_argument is deployed on the device

<!--- Remove any that don't apply: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
