### PR TITLE
feat: Add `type` parameter to `CustomURLCategory` object

### DIFF
--- a/panos/objects.py
+++ b/panos/objects.py
@@ -638,6 +638,7 @@ class CustomUrlCategory(VersionedPanObject):
 
         params.append(VersionedParamPath("url_value", path="list", vartype="member"))
         params.append(VersionedParamPath("description", path="description"))
+        params.append(VersionedParamPath("type"))
 
         self._params = tuple(params)
 


### PR DESCRIPTION
## Description

Add missing `type` parameter to `CustomURLCategory` object

## Motivation and Context

This parameter was added to PAN-OS so needs to be added to this SDK

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
