### PR TITLE
Fixed typo - changed leftover pandevice to panos

### DIFF
--- a/panos/network.py
+++ b/panos/network.py
@@ -497,7 +497,7 @@ class Interface(VsysOperations):
                     entry = counters["ifnet"]["ifnet"]["entry"][0]
 
             # Convert strings to integers, if they are integers
-            entry.update((k, pandevice.convert_if_int(v)) for k, v in entry.items())
+            entry.update((k, panos.convert_if_int(v)) for k, v in entry.items())
 
             # If empty dictionary (no results) it usually means the interface is not
             # configured, so return None

--- a/panos/panorama.py
+++ b/panos/panorama.py
@@ -600,7 +600,7 @@ class Panorama(base.PanDevice):
                         "entry/devices/entry[@name='%s']" % fw_entry.get("name")
                     )
                     if fw_entry_op is not None:
-                        pandevice.xml_combine(fw_entry, fw_entry_op)
+                        panos.xml_combine(fw_entry, fw_entry_op)
 
         dg = DeviceGroup()
         dg.parent = self


### PR DESCRIPTION
## Description

Changed a leftover `pandevice` reference to `panos`

## Motivation and Context

Fixes a `NameError: pandevice is not defined` exception when calling `panorama.refresh_devices` method.

## How Has This Been Tested?

Instead of said `NameError` we actually get back the list of device groups :)

## Types of changes

<!--- What types of changes does your code introduce? -->

- Bug fix (non-breaking change which fixes an issue)

