### PR TITLE
feat: Add `PanDevice.plugins()`

### DIFF
--- a/panos/base.py
+++ b/panos/base.py
@@ -5235,3 +5235,47 @@ class PanDevice(PanObject):
         fmt = "%a %b %d %H:%M:%S %Z %Y"
         text = res.text.strip()
         return datetime.strptime(text, fmt)
+
+    def plugins(self):
+        """Returns plugin information.
+
+        Each dict in the list returned has the following keys:
+            * name
+            * version
+            * release_date
+            * release_note_url
+            * package_file
+            * size
+            * platform
+            * installed
+            * downloaded
+
+        Returns:
+            list of dicts
+        """
+        # Older versions of PAN-OS do not have this command, so if we get an
+        # exception, just return None.
+        try:
+            res = self.op("<show><plugins><packages/></plugins></show>", cmd_xml=False)
+        except err.PanDeviceError:
+            return None
+
+        ans = []
+        for o in res.findall("./result/plugins/entry"):
+            ans.append(
+                {
+                    "name": o.find("./name").text,
+                    "version": o.find("./version").text,
+                    "release_date": o.find("./release-date").text,
+                    "release_note_url": (
+                        o.find("./release-note-url").text or ""
+                    ).strip(),
+                    "package_file": o.find("./pkg-file").text,
+                    "size": o.find("./size").text,
+                    "platform": o.find("./platform").text,
+                    "installed": o.find("./installed").text,
+                    "downloaded": o.find("./downloaded").text,
+                }
+            )
+
+        return ans

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1349,8 +1349,9 @@ class TestPanDevice(unittest.TestCase):
         ]
 
         spec = {
-            "op.return_value": ET.fromstring("".join(resp)),
+            "return_value": ET.fromstring("".join(resp)),
         }
+        self.obj.op = mock.Mock(**spec)
 
         ans = self.obj.plugins()
         self.assertTrue(ans is not None)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1326,5 +1326,48 @@ class TestTree(unittest.TestCase):
         self.assertEqual(ret_val, expected)
 
 
+class TestPanDevice(unittest.TestCase):
+    def setUp(self):
+        self.obj = Base.PanObject("localhost", "admin", "admin", "secret")
+        self.obj._version_info = (99, 0, 0)
+
+    def test_plugins_empty_release_note(self):
+        resp = [
+            '<response status="success"><result><plugins>',
+            "<entry>",
+            "<name>vm_series</name>",
+            "<version>1.0.11</version>",
+            "<release-date>Built-in</release-date>",
+            "<release-note-url><![CDATA[]]></release-note-url>",
+            "<pkg-file>vm_series-1.0.11</pkg-file>",
+            "<size>15M</size>",
+            "<platform>any</platform>",
+            "<installed>yes</installed>",
+            "<downloaded>yes</downloaded>",
+            "</entry>",
+            "</plugins></result></response>",
+        ]
+
+        spec = {
+            "op.return_value": ET.fromstring("".join(resp)),
+        }
+
+        ans = self.obj.plugins()
+        self.assertTrue(ans is not None)
+        self.assertTrue(len(ans) == 1)
+
+        ad = ans[0]
+        self.assertTrue(isinstance(ad, dict))
+        self.assertEqual(ad.get("name"), "vm_series")
+        self.assertEqual(ad.get("version"), "1.0.11")
+        self.assertEqual(ad.get("release_date"), "Built-in")
+        self.assertEqual(ad.get("release_note_url"), "")
+        self.assertEqual(ad.get("package_file"), "vm_series-1.0.11")
+        self.assertEqual(ad.get("size"), "15M")
+        self.assertEqual(ad.get("platform"), "any")
+        self.assertEqual(ad.get("installed"), "yes")
+        self.assertEqual(ad.get("downloaded"), "yes")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1355,6 +1355,7 @@ class TestPanDevice(unittest.TestCase):
 
         ans = self.obj.plugins()
         self.assertTrue(ans is not None)
+        self.assertTrue(isinstance(ans, list))
         self.assertTrue(len(ans) == 1)
 
         ad = ans[0]

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1328,7 +1328,7 @@ class TestTree(unittest.TestCase):
 
 class TestPanDevice(unittest.TestCase):
     def setUp(self):
-        self.obj = Base.PanObject("localhost", "admin", "admin", "secret")
+        self.obj = Base.PanDevice("localhost", "admin", "admin", "secret")
         self.obj._version_info = (99, 0, 0)
 
     def test_plugins_empty_release_note(self):


### PR DESCRIPTION
This adds a new function to all `PanDevice` objects, `plugins()`, that returns
a list of dicts of plugin information from PAN-OS.  This function initially
only existed on Panorama, but later existed on firewall as well.

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested against a 9.1 VM firewall and a 7.1 firewall (which doesn't support this `show` command).

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
