### PR TITLE
feat: Add new tag colors

### DIFF
--- a/panos/objects.py
+++ b/panos/objects.py
@@ -132,7 +132,7 @@ class Tag(VersionedPanObject):
 
     @staticmethod
     def color_code(color_name):
-        """Returns the color code for a color
+        """Return the color code for a color
 
         Args:
             color_name (str): One of the following colors:
@@ -172,6 +172,32 @@ class Tag(VersionedPanObject):
             "black": 14,
             "gold": 15,
             "brown": 16,
+            "olive": 17,
+            # there is no color18
+            "maroon": 19,
+            "red-orange": 20,
+            "yellow-orange": 21,
+            "forest green": 22,
+            "turquoise blue": 23,
+            "azure blue": 24,
+            "cerulean blue": 25,
+            "midnight blue": 26,
+            "medium blue": 27,
+            "cobalt blue": 28,
+            "violet blue": 29,
+            "blue violet": 30,
+            "medium violet": 31,
+            "medium rose": 32,
+            "lavender": 33,
+            "orchid": 34,
+            "thistle": 35,
+            "peach": 36,
+            "salmon": 37,
+            "magenta": 38,
+            "red violet": 39,
+            "mahogany": 40,
+            "burnt sienna": 41,
+            "chestnut": 42,
         }
         if color_name not in colors:
             raise ValueError("Color '{0}' is not valid".format(color_name))


### PR DESCRIPTION
## Description

PAN-OS added new tag colors a while ago (I didn't check back further than PAN-OS 8.1, and it has all these colors), and pan-os-python was missing support.

## Motivation and Context

My tags needed the rich mahogany color.

## How Has This Been Tested?

Just added elements to the dictionary, didn't test against a live device.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes if appropriate.
- [X] All new and existing tests passed.
