### PR TITLE
ci: OS wasn’t being changed from matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Poetry
-        uses: dschep/install-poetry-action@v1.3
+        uses: Gr1N/setup-poetry@v3
         with:
-          version: 1.0.10
+          poetry-version: 1.0.10
 
       - name: Get poetry cache directory
         id: poetry-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]


### PR DESCRIPTION
## Description

Noticed this in a repository that I copy/pasted the workflow from here.  Tests were only being run on Ubuntu.

## Motivation and Context

This runs tests on the different operating systems in `matrix.os`, not just `ubuntu-latest`.

## How Has This Been Tested?

Verified **Set up job** step in workflow reports different operating systems.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes if appropriate.
- [X] All new and existing tests passed.
