### PR TITLE
fix: Anti-replay specified twice in IpsecTunnel

### DIFF
--- a/panos/network.py
+++ b/panos/network.py
@@ -3951,7 +3951,6 @@ class IpsecTunnel(VersionedPanObject):
     Args:
         name: IPSec tunnel name
         tunnel_interface: apply IPSec VPN tunnels to tunnel interface
-        anti_replay (bool): enable anti-replay check on this tunnel
         ipv6 (bool): (7.0+) use IPv6 for the IPSec tunnel
         type: auto-key (default), manual-key, or global-protect-satellite
         ak_ike_gateway (string/list): IKE gateway name
@@ -4025,9 +4024,6 @@ class IpsecTunnel(VersionedPanObject):
         params = []
 
         params.append(VersionedParamPath("tunnel_interface", path="tunnel-interface"))
-        params.append(
-            VersionedParamPath("anti_replay", path="anti-replay", vartype="yesno")
-        )
         params.append(VersionedParamPath("ipv6", exclude=True))
         params[-1].add_profile("7.0.0", vartype="yesno", path="ipv6")
         params.append(


### PR DESCRIPTION
## Description

`anti_replay` was listed as an argument twice in `IpsecTunnel`, which would override any set to `False`.

## Motivation and Context

Reported as an issue in Ansible Collection.

## How Has This Been Tested?

Tested against PAN-OS 10.0.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes if appropriate.
- [X] All new and existing tests passed.
