### PR TITLE
fix: Bulk functions now work with single elements

### DIFF
--- a/panos/base.py
+++ b/panos/base.py
@@ -1827,6 +1827,8 @@ class PanObject(object):
         dev, instances, vsys_dict = self._gather_bulk_info("create_similar")
         if not instances:
             return
+        elif len(instances) == 1:
+            return self.create()
 
         # The new root tag is the last tag in the xpath, while the new xpath
         # is what remains.
@@ -1872,6 +1874,8 @@ class PanObject(object):
         dev, instances, vsys_dict = self._gather_bulk_info("apply_similar")
         if not instances:
             return
+        elif len(instances) == 1:
+            return self.apply()
 
         # The new root tag is the last tag in the xpath, while the new xpath
         # is what remains.
@@ -1911,6 +1915,8 @@ class PanObject(object):
         dev, instances, vsys_dict = self._gather_bulk_info("delete_similar")
         if not instances:
             return
+        elif len(instances) == 1:
+            return self.delete()
 
         # This operation is only supported for entry/member objects.
         if self.SUFFIX not in (ENTRY, MEMBER):


### PR DESCRIPTION
This affects `create_similar()`, `apply_similar()`, and `delete_similar()`.

Instead of assuming that multiple instances will be found, if only a single
instance is found, then it has to be the current object, so just invoke
`create()`, `apply()`, or `delete()` on the current object.

Fixes #275

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
