### PR TITLE
fix: PanDevice.clock: Use `datetime.datetime.strptime` instead of `datetime.strptime`

### DIFF
--- a/panos/base.py
+++ b/panos/base.py
@@ -5247,7 +5247,7 @@ class PanDevice(PanObject):
 
         fmt = "%a %b %d %H:%M:%S %Z %Y"
         text = res.text.strip()
-        return datetime.strptime(text, fmt)
+        return datetime.datetime.strptime(text, fmt)
 
     def plugins(self):
         """Returns plugin information.


### PR DESCRIPTION
Refers to issue https://github.com/PaloAltoNetworks/pan-os-python/issues/277

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
