### PR TITLE
Feature: path monitoring route

### DIFF
--- a/panos/network.py
+++ b/panos/network.py
@@ -1746,6 +1746,10 @@ class StaticRoute(VersionedPanObject):
     """
 
     SUFFIX = ENTRY
+    CHILDTYPES = (
+        "network.StaticRoutePathMonitor",
+    )
+
 
     def _setup(self):
         # xpaths
@@ -1817,6 +1821,57 @@ class StaticRouteV6(VersionedPanObject):
         params.append(
             VersionedParamPath("metric", default=10, vartype="int", path="metric")
         )
+
+        self._params = tuple(params)
+
+class StaticRoutePathMonitor(VersionedPanObject):
+    """PathMonitor Route
+
+    Add to a :class:`panos.network.VirtualRouter` instance.
+
+    Args:
+        enabled: bool
+        Failure condition: 
+            - any (default)
+            - all
+        Preemptive_HoldTime:
+            - 2 min (default)
+    """
+    SUFFIX = ENTRY
+
+    def _setup(self):
+        # xpaths
+        self._xpaths.add_profile(value="/path-monitor")
+
+        # params
+        params = []
+
+        params.append(
+            VersionedParamPath(
+                "enable_path_monitor",
+                vartype="yesno",
+                path="/enable",
+            )
+        )
+       
+        params.append(
+            VersionedParamPath(
+                "failure_condition", 
+                default=any, 
+                values=("all", "any"), 
+                path="/failure-condition"
+            )
+        )
+
+        params.append(
+            VersionedParamPath(
+                "preemptive_holdtime", 
+                default=2, 
+                vartype="int", 
+                path="/hold-time"
+            )
+        )
+
 
         self._params = tuple(params)
 

--- a/panos/network.py
+++ b/panos/network.py
@@ -1751,7 +1751,7 @@ class StaticRoute(VersionedPanObject):
     """
 
     SUFFIX = ENTRY
-    CHILDTYPES = ("network.PathMonitorDestinaton",)
+    CHILDTYPES = ("network.PathMonitorDestination",)
 
     def _setup(self):
         # xpaths
@@ -1850,10 +1850,11 @@ class StaticRouteV6(VersionedPanObject):
 
         self._params = tuple(params)
 
-class PathMonitorDestinaton(VersionedPanObject):
+class PathMonitorDestination(VersionedPanObject):
     """PathMonitorDestinaton Route
 
     Args:
+        name (str): Name of PathMonitorDestinaton
         enabled: bool
         source_ip:
         destination_ip:
@@ -1875,11 +1876,11 @@ class PathMonitorDestinaton(VersionedPanObject):
         )
 
         params.append(
-            VersionedParamPath("source_ip",vartype="entry",path="/source")
+            VersionedParamPath("source",path="/source")
         ) 
       
         params.append(
-            VersionedParamPath("destination_ip",vartype="entry",path="/destination")
+            VersionedParamPath("destination",path="/destination")
         )
 
         params.append(

--- a/panos/network.py
+++ b/panos/network.py
@@ -1743,8 +1743,8 @@ class StaticRoute(VersionedPanObject):
         admin_dist (str): Administrative distance
         metric (int): Metric (Default: 10)
         enable_path_monitor (bool): Enable Path Monitor
-        failure_condition: Path Monitor failure condition set 'any' or 'all' 
-        preemptive_holdtime (int): Path Monitor Preemptive Hold Time in minutes
+        failure_condition (str): Path Monitor failure condition set 'any' or 'all' 
+        preemptive_hold_time (int): Path Monitor Preemptive Hold Time in minutes
         
     """
 
@@ -1775,24 +1775,21 @@ class StaticRoute(VersionedPanObject):
         params.append(
             VersionedParamPath("metric", default=10, vartype="int", path="metric")
         )
-
         params.append(
             VersionedParamPath(
-                "enable_path_monitor", path="/path-monitor/enable", vartype="yesno"
+                "enable_path_monitor", path="path-monitor/enable", vartype="yesno"
             )
         )
-
         params.append(
             VersionedParamPath(
                 "failure_condition",
                 values=("all", "any"),
-                path="/path-monitor/failure-condition",
+                path="path-monitor/failure-condition",
             )
         )
-
         params.append(
             VersionedParamPath(
-                "preemptive_holdtime", vartype="int", path="/path-monitor/hold-time"
+                "preemptive_hold_time", vartype="int", path="path-monitor/hold-time"
             )
         )
 
@@ -1812,10 +1809,14 @@ class StaticRouteV6(VersionedPanObject):
         interface (str): Next hop interface
         admin_dist (str): Administrative distance
         metric (int): Metric (Default: 10)
+        enable_path_monitor (bool): Enable Path Monitor
+        failure_condition (str): Path Monitor failure condition set 'any' or 'all' 
+        preemptive_hold_time (int): Path Monitor Preemptive Hold Time in minutes
 
     """
 
     SUFFIX = ENTRY
+    CHILDTYPES = ("network.PathMonitorDestination",)
 
     def _setup(self):
         # xpaths
@@ -1841,6 +1842,23 @@ class StaticRouteV6(VersionedPanObject):
         params.append(
             VersionedParamPath("metric", default=10, vartype="int", path="metric")
         )
+        params.append(
+            VersionedParamPath(
+                "enable_path_monitor", path="path-monitor/enable", vartype="yesno"
+            )
+        )
+        params.append(
+            VersionedParamPath(
+                "failure_condition",
+                values=("all", "any"),
+                path="path-monitor/failure-condition",
+            )
+        )
+        params.append(
+            VersionedParamPath(
+                "preemptive_hold_time", vartype="int", path="path-monitor/hold-time"
+            )
+        )
 
         self._params = tuple(params)
 
@@ -1850,7 +1868,7 @@ class PathMonitorDestination(VersionedPanObject):
 
     Args:
         name (str): Name of Path Monitor Destination 
-        enabled (bool): Enable Path Monitor Destination 
+        enable (bool): Enable Path Monitor Destination 
         source (str): Source ip of interface
         destination (str): Destination ip 
         interval (int): Ping Interval (sec) (Default: 3)
@@ -1867,18 +1885,14 @@ class PathMonitorDestination(VersionedPanObject):
         # params
         params = []
 
-        params.append(VersionedParamPath("enable", vartype="yesno", path="/enable"))
-
-        params.append(VersionedParamPath("source", path="/source"))
-
-        params.append(VersionedParamPath("destination", path="/destination"))
-
+        params.append(VersionedParamPath("enable", vartype="yesno", path="enable"))
+        params.append(VersionedParamPath("source", path="source"))
+        params.append(VersionedParamPath("destination", path="destination"))
         params.append(
-            VersionedParamPath("interval", default=3, vartype="int", path="/interval")
+            VersionedParamPath("interval", default=3, vartype="int", path="interval")
         )
-
         params.append(
-            VersionedParamPath("count", default=5, vartype="int", path="/count")
+            VersionedParamPath("count", default=5, vartype="int", path="count")
         )
 
         self._params = tuple(params)

--- a/panos/network.py
+++ b/panos/network.py
@@ -1780,7 +1780,7 @@ class StaticRoute(VersionedPanObject):
             VersionedParamPath(
                 "enable_path_monitor",
                 vartype="yesno",
-                path="/path-monitor/enable",
+                path="/path-monitor/enable"
             )
         )
 

--- a/panos/network.py
+++ b/panos/network.py
@@ -1857,7 +1857,7 @@ class StaticRoutePathMonitor(VersionedPanObject):
         params.append(
             VersionedParamPath(
                 "failure_condition", 
-                default=any, 
+                default="any", 
                 values=("all", "any"), 
                 path="/failure-condition"
             )

--- a/panos/network.py
+++ b/panos/network.py
@@ -1746,9 +1746,9 @@ class StaticRoute(VersionedPanObject):
     """
 
     SUFFIX = ENTRY
-#    CHILDTYPES = (
-#        "network.StaticRoutePathMonitor",
-#    )
+    CHILDTYPES = (
+        "network.StaticRoutePathMonitor",
+    )
 
 
     def _setup(self):
@@ -1776,6 +1776,7 @@ class StaticRoute(VersionedPanObject):
             VersionedParamPath("metric", default=10, vartype="int", path="metric")
         )
 
+'''
         params.append(
             VersionedParamPath(
                 "enable_path_monitor",
@@ -1801,6 +1802,7 @@ class StaticRoute(VersionedPanObject):
                 path="/path-monitor/hold-time"
             )
         ) 
+'''
 
         self._params = tuple(params)
 
@@ -1875,8 +1877,9 @@ class StaticRoutePathMonitor(VersionedPanObject):
         params.append(
             VersionedParamPath(
                 "enable_path_monitor",
+                default=True,
                 vartype="yesno",
-                path="/enable",
+                path="enable",
             )
         )
        
@@ -1885,7 +1888,7 @@ class StaticRoutePathMonitor(VersionedPanObject):
                 "failure_condition", 
                 default="any", 
                 values=("all", "any"), 
-                path="/failure-condition"
+                path="failure-condition"
             )
         )
 
@@ -1894,7 +1897,7 @@ class StaticRoutePathMonitor(VersionedPanObject):
                 "preemptive_holdtime", 
                 default=2, 
                 vartype="int", 
-                path="/hold-time"
+                path="hold-time"
             )
         )
 

--- a/panos/network.py
+++ b/panos/network.py
@@ -1746,9 +1746,9 @@ class StaticRoute(VersionedPanObject):
     """
 
     SUFFIX = ENTRY
-    CHILDTYPES = (
-        "network.StaticRoutePathMonitor",
-    )
+#    CHILDTYPES = (
+#        "network.StaticRoutePathMonitor",
+#    )
 
 
     def _setup(self):
@@ -1775,22 +1775,19 @@ class StaticRoute(VersionedPanObject):
         params.append(
             VersionedParamPath("metric", default=10, vartype="int", path="metric")
         )
-        
-        self._params = tuple(params)
 
-'''
         params.append(
             VersionedParamPath(
                 "enable_path_monitor",
                 vartype="yesno",
-                path="/path-monitor/enable"
+                path="/path-monitor/enable",
             )
         )
 
         params.append(
             VersionedParamPath(
                 "failure_condition", 
-                default="any", 
+                #default="any", 
                 values=("all", "any"), 
                 path="/path-monitor/failure-condition"
             )
@@ -1799,13 +1796,13 @@ class StaticRoute(VersionedPanObject):
         params.append(
             VersionedParamPath(
                 "preemptive_holdtime", 
-                default=2, 
+                #default=2, 
                 vartype="int", 
                 path="/path-monitor/hold-time"
             )
         ) 
-'''
-       
+
+        self._params = tuple(params)
 
 
 class StaticRouteV6(VersionedPanObject):
@@ -1878,9 +1875,8 @@ class StaticRoutePathMonitor(VersionedPanObject):
         params.append(
             VersionedParamPath(
                 "enable_path_monitor",
-                default=True,
                 vartype="yesno",
-                path="enable",
+                path="/enable",
             )
         )
        
@@ -1889,7 +1885,7 @@ class StaticRoutePathMonitor(VersionedPanObject):
                 "failure_condition", 
                 default="any", 
                 values=("all", "any"), 
-                path="failure-condition"
+                path="/failure-condition"
             )
         )
 
@@ -1898,7 +1894,7 @@ class StaticRoutePathMonitor(VersionedPanObject):
                 "preemptive_holdtime", 
                 default=2, 
                 vartype="int", 
-                path="hold-time"
+                path="/hold-time"
             )
         )
 

--- a/panos/network.py
+++ b/panos/network.py
@@ -1742,10 +1742,16 @@ class StaticRoute(VersionedPanObject):
         interface (str): Next hop interface
         admin_dist (str): Administrative distance
         metric (int): Metric (Default: 10)
-
+        enable_path_monitor: bool
+        Failure condition (choices): 
+            - any 
+            - all
+        Preemptive_HoldTime: (int)
+        
     """
 
     SUFFIX = ENTRY
+    CHILDTYPES = ("network.PathMonitorDestinaton",)
 
     def _setup(self):
         # xpaths
@@ -1844,54 +1850,45 @@ class StaticRouteV6(VersionedPanObject):
 
         self._params = tuple(params)
 
-class StaticRoutePathMonitor(VersionedPanObject):
-    """PathMonitor Route
-
-    Add to a :class:`panos.network.VirtualRouter` instance.
+class PathMonitorDestinaton(VersionedPanObject):
+    """PathMonitorDestinaton Route
 
     Args:
         enabled: bool
-        Failure condition: 
-            - any (default)
-            - all
-        Preemptive_HoldTime:
-            - 2 min (default)
+        source_ip:
+        destination_ip:
+        interval: (int)
+        count: (int)
+       
     """
     SUFFIX = ENTRY
 
     def _setup(self):
         # xpaths
-        self._xpaths.add_profile(value="/path-monitor")
+        self._xpaths.add_profile(value="/monitor-destinations")
 
         # params
         params = []
 
         params.append(
-            VersionedParamPath(
-                "enable_path_monitor",
-                vartype="yesno",
-                path="/enable",
-            )
-        )
-       
-        params.append(
-            VersionedParamPath(
-                "failure_condition", 
-                default="any", 
-                values=("all", "any"), 
-                path="/failure-condition"
-            )
+            VersionedParamPath("enable",vartype="yesno",path="/enable")
         )
 
         params.append(
-            VersionedParamPath(
-                "preemptive_holdtime", 
-                default=2, 
-                vartype="int", 
-                path="/hold-time"
-            )
+            VersionedParamPath("source_ip",vartype="entry",path="/source")
+        ) 
+      
+        params.append(
+            VersionedParamPath("destination_ip",vartype="entry",path="/destination")
         )
 
+        params.append(
+            VersionedParamPath("interval",default=3,vartype="int",path="/interval")
+        )
+
+        params.append(
+            VersionedParamPath("count",default=5,vartype="int",path="/count")
+        ) 
 
         self._params = tuple(params)
 

--- a/panos/network.py
+++ b/panos/network.py
@@ -1775,6 +1775,8 @@ class StaticRoute(VersionedPanObject):
         params.append(
             VersionedParamPath("metric", default=10, vartype="int", path="metric")
         )
+        
+        self._params = tuple(params)
 
 '''
         params.append(
@@ -1803,8 +1805,7 @@ class StaticRoute(VersionedPanObject):
             )
         ) 
 '''
-
-        self._params = tuple(params)
+       
 
 
 class StaticRouteV6(VersionedPanObject):

--- a/panos/network.py
+++ b/panos/network.py
@@ -1746,9 +1746,9 @@ class StaticRoute(VersionedPanObject):
     """
 
     SUFFIX = ENTRY
-    CHILDTYPES = (
-        "network.StaticRoutePathMonitor",
-    )
+#    CHILDTYPES = (
+#        "network.StaticRoutePathMonitor",
+#    )
 
 
     def _setup(self):
@@ -1775,6 +1775,32 @@ class StaticRoute(VersionedPanObject):
         params.append(
             VersionedParamPath("metric", default=10, vartype="int", path="metric")
         )
+
+        params.append(
+            VersionedParamPath(
+                "enable_path_monitor",
+                vartype="yesno",
+                path="/path-monitor/enable",
+            )
+        )
+
+        params.append(
+            VersionedParamPath(
+                "failure_condition", 
+                default="any", 
+                values=("all", "any"), 
+                path="/path-monitor/failure-condition"
+            )
+        )
+
+        params.append(
+            VersionedParamPath(
+                "preemptive_holdtime", 
+                default=2, 
+                vartype="int", 
+                path="/path-monitor/hold-time"
+            )
+        ) 
 
         self._params = tuple(params)
 

--- a/panos/network.py
+++ b/panos/network.py
@@ -1775,8 +1775,8 @@ class StaticRoute(VersionedPanObject):
         params.append(
             VersionedParamPath(
                 "enable_path_monitor",
-                vartype="yesno",
                 path="/path-monitor/enable",
+                vartype="yesno"
             )
         )
 

--- a/panos/network.py
+++ b/panos/network.py
@@ -1865,7 +1865,7 @@ class PathMonitorDestinaton(VersionedPanObject):
 
     def _setup(self):
         # xpaths
-        self._xpaths.add_profile(value="/monitor-destinations")
+        self._xpaths.add_profile(value="/path-monitor/monitor-destinations")
 
         # params
         params = []

--- a/panos/network.py
+++ b/panos/network.py
@@ -1746,10 +1746,6 @@ class StaticRoute(VersionedPanObject):
     """
 
     SUFFIX = ENTRY
-#    CHILDTYPES = (
-#        "network.StaticRoutePathMonitor",
-#    )
-
 
     def _setup(self):
         # xpaths
@@ -1787,7 +1783,6 @@ class StaticRoute(VersionedPanObject):
         params.append(
             VersionedParamPath(
                 "failure_condition", 
-                #default="any", 
                 values=("all", "any"), 
                 path="/path-monitor/failure-condition"
             )
@@ -1796,7 +1791,6 @@ class StaticRoute(VersionedPanObject):
         params.append(
             VersionedParamPath(
                 "preemptive_holdtime", 
-                #default=2, 
                 vartype="int", 
                 path="/path-monitor/hold-time"
             )

--- a/panos/network.py
+++ b/panos/network.py
@@ -1778,27 +1778,23 @@ class StaticRoute(VersionedPanObject):
 
         params.append(
             VersionedParamPath(
-                "enable_path_monitor",
-                path="/path-monitor/enable",
-                vartype="yesno"
+                "enable_path_monitor", path="/path-monitor/enable", vartype="yesno"
             )
         )
 
         params.append(
             VersionedParamPath(
-                "failure_condition", 
-                values=("all", "any"), 
-                path="/path-monitor/failure-condition"
+                "failure_condition",
+                values=("all", "any"),
+                path="/path-monitor/failure-condition",
             )
         )
 
         params.append(
             VersionedParamPath(
-                "preemptive_holdtime", 
-                vartype="int", 
-                path="/path-monitor/hold-time"
+                "preemptive_holdtime", vartype="int", path="/path-monitor/hold-time"
             )
-        ) 
+        )
 
         self._params = tuple(params)
 
@@ -1848,6 +1844,7 @@ class StaticRouteV6(VersionedPanObject):
 
         self._params = tuple(params)
 
+
 class PathMonitorDestination(VersionedPanObject):
     """PathMonitorDestination Static Route 
 
@@ -1860,6 +1857,7 @@ class PathMonitorDestination(VersionedPanObject):
         count (int): Ping count (Default: 5)
        
     """
+
     SUFFIX = ENTRY
 
     def _setup(self):
@@ -1869,25 +1867,19 @@ class PathMonitorDestination(VersionedPanObject):
         # params
         params = []
 
+        params.append(VersionedParamPath("enable", vartype="yesno", path="/enable"))
+
+        params.append(VersionedParamPath("source", path="/source"))
+
+        params.append(VersionedParamPath("destination", path="/destination"))
+
         params.append(
-            VersionedParamPath("enable",vartype="yesno",path="/enable")
+            VersionedParamPath("interval", default=3, vartype="int", path="/interval")
         )
 
         params.append(
-            VersionedParamPath("source",path="/source")
-        ) 
-      
-        params.append(
-            VersionedParamPath("destination",path="/destination")
+            VersionedParamPath("count", default=5, vartype="int", path="/count")
         )
-
-        params.append(
-            VersionedParamPath("interval",default=3,vartype="int",path="/interval")
-        )
-
-        params.append(
-            VersionedParamPath("count",default=5,vartype="int",path="/count")
-        ) 
 
         self._params = tuple(params)
 

--- a/panos/network.py
+++ b/panos/network.py
@@ -1742,11 +1742,9 @@ class StaticRoute(VersionedPanObject):
         interface (str): Next hop interface
         admin_dist (str): Administrative distance
         metric (int): Metric (Default: 10)
-        enable_path_monitor: bool
-        Failure condition (choices): 
-            - any 
-            - all
-        Preemptive_HoldTime: (int)
+        enable_path_monitor (bool): Enable Path Monitor
+        failure_condition: Path Monitor failure condition set 'any' or 'all' 
+        preemptive_holdtime (int): Path Monitor Preemptive Hold Time in minutes
         
     """
 
@@ -1851,15 +1849,15 @@ class StaticRouteV6(VersionedPanObject):
         self._params = tuple(params)
 
 class PathMonitorDestination(VersionedPanObject):
-    """PathMonitorDestinaton Route
+    """PathMonitorDestination of static route 
 
     Args:
-        name (str): Name of PathMonitorDestinaton
-        enabled: bool
-        source_ip:
-        destination_ip:
-        interval: (int)
-        count: (int)
+        name (str): Name of Path Monitor Destination 
+        enabled (bool): Enable Path Monitor Destination 
+        source (str): Source ip of interface
+        destination (str): Destination ip 
+        interval (int): Ping Interval (sec) (Default: 3)
+        count (int): Ping count (Default: 5)
        
     """
     SUFFIX = ENTRY

--- a/panos/network.py
+++ b/panos/network.py
@@ -1849,7 +1849,7 @@ class StaticRouteV6(VersionedPanObject):
         self._params = tuple(params)
 
 class PathMonitorDestination(VersionedPanObject):
-    """PathMonitorDestination of static route 
+    """PathMonitorDestination Static Route 
 
     Args:
         name (str): Name of Path Monitor Destination 


### PR DESCRIPTION
## Feature / Add ability to enable Path Monitoring in Virtual Router -> Static Route

Enabled the check box "Path Monitoring" under Virtual Router -> Static Route

This is done by adding 3 new params in the existing class StaticRoute.

Add "Path Monitoring Destination" under Virtual Router -> Static Route -> Path Monitoring

This is done by creating an new class PathMonitorDestination in network.py

## Motivation and Context

Adds a new functionality.

## How Has This Been Tested?

This has been tested in a physical firewall 5220 version 9.0.10 with python 3.6
The python script that i used for the test.

    fw = firewall.Firewall(HOSTNAME, USERNAME, api_key=KEY)

    router = fw.add(network.VirtualRouter(name='VR2'))

    static_route = {
        'name': 'route2',
        'destination': '1.1.1.1/32',
        'nexthop_type': 'ip-address',
        'nexthop': '169.254.255.103',
	'enable_path_monitor': True,
	'failure_condition' : 'any',
	'preemptive_holdtime' : 4
    }

    static = router.add(network.StaticRoute(**static_route))
    static.create()

    monitor_destination1 = {
	'name': 'test',
	'enable': True,
	'source': '10.212.100.14/29',
	'destination': '1.1.1.1'
    }

    monitor = static.add(network.PathMonitorDestination(**monitor_destination1))
    monitor.create()

    monitor_destination2 = {
        'name': 'test2',
        'enable': True,
        'source': '10.212.100.14/29',
        'destination': '2.2.2.2'
    }

    monitor2 = static.add(network.PathMonitorDestination(**monitor_destination2))
    monitor2.create()

the result below. 

                  route2 {
                    destination 1.1.1.1/32;
                    nexthop {
                      ip-address 169.254.255.103;
                    }
                    metric 10;
                    path-monitor {
                      enable yes;
                      failure-condition any;
                      hold-time 4;
                      monitor-destinations {
                        test {
                          enable yes;
                          source 10.212.100.14/29;
                          destination 1.1.1.1;
                          interval 3;
                          count 5;
                        }
                        test2 {
                          enable yes;
                          source 10.212.100.14/29;
                          destination 2.2.2.2;
                          interval 3;
                          count 5;
                        }
                      }
                    }
                  }
                 }
               }

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
