### PR TITLE
fix: correct user-id tag_user / untag_user

### DIFF
--- a/panos/userid.py
+++ b/panos/userid.py
@@ -674,7 +674,7 @@ class UserId(object):
         # Find the tags section for this specific user.
         entries = ru.findall("./entry")
         for entry in entries:
-            if entry.attrib["name"] == user:
+            if entry.attrib["user"] == user:
                 te = entry.find("./tag")
                 break
         else:
@@ -718,7 +718,7 @@ class UserId(object):
         # Find the tags section for this specific user.
         entries = uu.findall("./entry")
         for entry in entries:
-            if entry.attrib["name"] == user:
+            if entry.attrib["user"] == user:
                 break
         else:
             entry = ET.SubElement(uu, "entry", {"user": user,})

--- a/tests/test_userid.py
+++ b/tests/test_userid.py
@@ -61,6 +61,24 @@ class TestUserId(unittest.TestCase):
 
         fw._xapi_private.user_id.assert_called_once_with(cmd=expected, vsys=vsys)
 
+    def test_batch_tag_user(self):
+        fw = panos.firewall.Firewall(
+            "fw1", "user", "passwd", "authkey", serial="Serial", vsys="vsys1"
+        )
+        fw.xapi
+        fw.userid.batch_start()
+        fw.userid.tag_user("user1", ["tag1",])
+        fw.userid.tag_user("user2", ["tag1",])
+
+    def test_batch_untag_user(self):
+        fw = panos.firewall.Firewall(
+            "fw1", "user", "passwd", "authkey", serial="Serial", vsys="vsys2"
+        )
+        fw.xapi
+        fw.userid.batch_start()
+        fw.userid.untag_user("user1", ["tag1",])
+        fw.userid.untag_user("user2", ["tag1",])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #287 - correcting attribute checked to "user" for both tag_user()
and untag_user()

New unittests have been added and pass successfully.