### PR TITLE
Better version refresh in `refresh_system_info()` and `refresh_devices()`

### DIFF
--- a/panos/base.py
+++ b/panos/base.py
@@ -3915,9 +3915,10 @@ class PanDevice(PanObject):
 
         Variables refreshed:
 
-        - version
+        - PAN-OS version
         - platform
         - serial
+        - content version (if this is a :class:`panos.firewall.Firewall`)
         - multi_vsys (if this is a :class:`panos.firewall.Firewall`)
 
         Returns:

--- a/panos/firewall.py
+++ b/panos/firewall.py
@@ -239,6 +239,7 @@ class Firewall(PanDevice):
 
         """
         super(Firewall, self)._save_system_info(system_info)
+        self.content_version = system_info["system"]["app-version"]
         self.multi_vsys = system_info["system"]["multi-vsys"] == "on"
 
     def element(self):

--- a/panos/firewall.py
+++ b/panos/firewall.py
@@ -342,13 +342,10 @@ class Firewall(PanDevice):
             )
         op_vars = (
             Var("serial"),
-            Var("ip-address", "management_ip"),
-            Var("sw-version", "version"),
             Var("multi-vsys", vartype="bool"),
             Var("vsys_id", "vsys", default="vsys1"),
             Var("vsys_name"),
             Var("ha/state/peer/serial", "serial_ha_peer"),
-            Var("connected", "state.connected"),
         )
         if len(xml[0]) > 1:
             # This is a 'show devices' op command
@@ -361,11 +358,15 @@ class Firewall(PanDevice):
                 system = fw.find_or_create(None, device.SystemSettings)
                 system.hostname = entry.findtext("hostname")
                 system.ip_address = entry.findtext("ip-address")
+                if entry.findtext("ipv6-address") != "unknown":
+                    system.ipv6_address = entry.findtext("ipv6-address")
                 # Add state
                 fw.state.connected = yesno(entry.findtext("connected"))
                 fw.state.unsupported_version = yesno(
                     entry.findtext("unsupported-version")
                 )
+                fw._set_version_and_version_info(entry.findtext("sw-version"))
+                fw.content_version = entry.findtext("app-version")
         else:
             # This is a config command
             # For each vsys, instantiate a new firewall


### PR DESCRIPTION
## Description

Save extra information including version, content_version, and ipv6 address when doing refresh methods.

## Motivation and Context

This change makes it easier to collect important information while getting the devices themselves, rather than having to make a second API call to get this information.

## How Has This Been Tested?

Tested on live devices.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
