### PR TITLE
feat: Add hit count support (opstate)

### DIFF
--- a/panos/base.py
+++ b/panos/base.py
@@ -2278,6 +2278,9 @@ class VersionedPanObject(PanObject):
 
         self._setup()
 
+        if hasattr(self, "_setup_opstate") and callable(self._setup_opstate):
+            self._setup_opstate()
+
         try:
             params = super(VersionedPanObject, self).__getattribute__("_params")
         except AttributeError:

--- a/panos/policies.py
+++ b/panos/policies.py
@@ -860,10 +860,20 @@ class RulebaseHitCount(object):
 class HitCount(object):
     """Hit count operational data."""
 
+    FIELDS = (
+        ("latest", "latest", "str"),
+        ("hit_count", "hit-count", "int"),
+        ("last_hit_timestamp", "last-hit-timestamp", "int"),
+        ("last_reset_timestamp", "last-reset-timestamp", "int"),
+        ("first_hit_timestamp", "first-hit-timestamp", "int"),
+        ("rule_creation_timestamp", "rule-creation-timestamp", "int"),
+        ("rule_modification_timestamp", "rule-modification-timestamp", "int"),
+    )
+
     def __init__(self, obj=None, name=None, elm=None):
         self.obj = obj
         self.name = name if obj is None else obj.uid
-        self._from(elm)
+        self._refresh_xml(elm)
 
     def refresh(self, elm=None):
         if elm is None and self.obj is not None:
@@ -871,28 +881,28 @@ class HitCount(object):
                 self.obj.HIT_COUNT_STYLE, [self.name,],
             )
         else:
-            self._from(elm)
+            self._refresh_xml(elm)
 
-    def _from(self, elm=None):
-        self.latest = self._str(elm, "latest")
-        self.hit_count = self._int(elm, "hit-count")
-        self.last_hit_timestamp = self._int(elm, "last-hit-timestamp")
-        self.last_reset_timestamp = self._int(elm, "last-reset-timestamp")
-        self.first_hit_timestamp = self._int(elm, "first-hit-timestamp")
-        self.rule_creation_timestamp = self._int(elm, "rule-creation-timestamp")
-        self.rule_modification_timestamp = self._int(elm, "rule-modification-timestamp")
+    def _refresh_xml(self, elm):
+        for param, path, param_type in self.FIELDS:
+            if param_type == "int":
+                setattr(self, param, self._int(elm, path))
+            else:
+                setattr(self, param, self._str(elm, path))
 
     def _str(self, elm, field):
         if elm is None:
-            return None
+            return
 
-        return elm.find("./{0}".format(field)).text
+        val = elm.find("./{0}".format(field))
+        if val is not None:
+            return val.text
 
     def _int(self, elm, field):
-        if elm is None:
-            return None
+        val = self._str(elm, field)
 
-        return int(elm.find("./{0}".format(field)).text)
+        if val is not None:
+            return int(val)
 
 
 class RuleOpState(object):

--- a/tests/test_opstate.py
+++ b/tests/test_opstate.py
@@ -1,0 +1,240 @@
+import xml.etree.ElementTree as ET
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from panos.firewall import Firewall
+from panos.policies import HitCount
+from panos.policies import Rulebase
+from panos.policies import SecurityRule
+
+
+HIT_COUNT_PREFIX = """
+<response>
+    <result>
+        <rule-hit-count>
+            <vsys>
+                <entry>
+                    <rule-base>
+                        <entry>
+                            <rules>
+"""
+
+HIT_COUNT_SUFFIX = """
+                            </rules>
+                        </entry>
+                    </rule-base>
+                </entry>
+            </vsys>
+        </rule-hit-count>
+    </result>
+</response>
+"""
+
+
+def _hit_count_fw_setup(*args):
+    fw = Firewall("127.0.0.1", "admin", "admin", "secret")
+    fw._version_info = (9999, 0, 0)
+
+    inner = "".join(ET.tostring(x, encoding="utf-8").decode("utf-8") for x in args)
+
+    fw.op = mock.Mock(
+        return_value=ET.fromstring(HIT_COUNT_PREFIX + inner + HIT_COUNT_SUFFIX,)
+    )
+
+    rb = Rulebase()
+    fw.add(rb)
+
+    return fw, rb
+
+
+def _hit_count_elm(
+    name,
+    latest="yes",
+    hit_count=0,
+    last_hit_timestamp=0,
+    last_reset_timestamp=0,
+    first_hit_timestamp=0,
+    rule_creation_timestamp=0,
+    rule_modification_timestamp=0,
+    obj=None,
+):
+    tmpl = """
+    <entry name="{0}">
+        <latest>{1}</latest>
+        <hit-count>{2}</hit-count>
+        <last-hit-timestamp>{3}</last-hit-timestamp>
+        <last-reset-timestamp>{4}</last-reset-timestamp>
+        <first-hit-timestamp>{5}</first-hit-timestamp>
+        <rule-creation-timestamp>{6}</rule-creation-timestamp>
+        <rule-modification-timestamp>{7}</rule-modification-timestamp>
+    </entry>"""
+
+    val = None
+    if obj is not None:
+        val = tmpl.format(
+            obj.name,
+            obj.latest,
+            obj.hit_count,
+            obj.last_hit_timestamp,
+            obj.last_reset_timestamp,
+            obj.first_hit_timestamp,
+            obj.rule_creation_timestamp,
+            obj.rule_modification_timestamp,
+        )
+    else:
+        val = tmpl.format(
+            name,
+            latest,
+            hit_count,
+            last_hit_timestamp,
+            last_reset_timestamp,
+            first_hit_timestamp,
+            rule_creation_timestamp,
+            rule_modification_timestamp,
+        )
+
+    return ET.fromstring(val)
+
+
+def _hit_count_eq(a, b):
+    for key in vars(a).keys():
+        if key == "obj":
+            continue
+        assert hasattr(b, key)
+        assert getattr(a, key) == getattr(b, key)
+
+
+def test_rulebase_hit_count_refresh_for_single_attached_security_rule():
+    name = "intrazone-default"
+    elm = _hit_count_elm(
+        name=name,
+        rule_creation_timestamp=1599752499,
+        rule_modification_timestamp=1599752499,
+    )
+    expected = HitCount(name=name, elm=elm)
+
+    fw, rb = _hit_count_fw_setup(elm)
+    o = SecurityRule(name)
+    rb.add(o)
+
+    assert not o.opstate.hit_count.rule_creation_timestamp
+
+    ans = rb.opstate.hit_count.refresh("security")
+
+    assert len(ans) == 1
+    assert o.uid in ans
+    _hit_count_eq(expected, ans[o.uid])
+    _hit_count_eq(expected, o.opstate.hit_count)
+
+
+def test_rulebase_hit_count_refresh_for_multiple_attached_security_rules():
+    n1 = "foo"
+    elm1 = _hit_count_elm(
+        name=n1,
+        hit_count=42,
+        rule_creation_timestamp=1599752499,
+        rule_modification_timestamp=1599752499,
+    )
+    e1 = HitCount(name=n1, elm=elm1)
+
+    n2 = "bar"
+    elm2 = _hit_count_elm(
+        name=n2,
+        hit_count=24,
+        rule_creation_timestamp=1234,
+        rule_modification_timestamp=5678,
+    )
+    e2 = HitCount(name=n2, elm=elm2)
+
+    fw, rb = _hit_count_fw_setup(elm1, elm2)
+    o1 = SecurityRule(n1)
+    rb.add(o1)
+
+    o2 = SecurityRule(n2)
+    rb.add(o2)
+
+    assert not o1.opstate.hit_count.hit_count
+    assert not o2.opstate.hit_count.hit_count
+
+    ans = rb.opstate.hit_count.refresh("security")
+
+    assert len(ans) == 2
+    assert o1.uid in ans
+    _hit_count_eq(e1, ans[o1.uid])
+    _hit_count_eq(e1, o1.opstate.hit_count)
+    assert o2.uid in ans
+    _hit_count_eq(e2, ans[o2.uid])
+    _hit_count_eq(e2, o2.opstate.hit_count)
+
+
+def test_rulebase_hit_count_refresh_for_all_rules_updates_attached_rule():
+    n1 = "intrazone-default"
+    elm1 = _hit_count_elm(
+        name=n1,
+        hit_count=1,
+        rule_creation_timestamp=1599752499,
+        rule_modification_timestamp=1599752499,
+    )
+    e1 = HitCount(name=n1, elm=elm1)
+
+    n2 = "interzone-default"
+    elm2 = _hit_count_elm(
+        name=n2,
+        hit_count=2,
+        rule_creation_timestamp=1599752499,
+        rule_modification_timestamp=1599752499,
+    )
+    e2 = HitCount(name=n2, elm=elm2)
+
+    name = "bar"
+    elm3 = _hit_count_elm(
+        name=name,
+        hit_count=24,
+        rule_creation_timestamp=1234,
+        rule_modification_timestamp=5678,
+    )
+    expected = HitCount(name=name, elm=elm3)
+
+    fw, rb = _hit_count_fw_setup(elm1, elm2, elm3)
+    o = SecurityRule(name)
+    rb.add(o)
+
+    assert not o.opstate.hit_count.hit_count
+
+    ans = rb.opstate.hit_count.refresh("security", all_rules=True)
+
+    assert len(ans) == 3
+    assert n1 in ans
+    _hit_count_eq(e1, ans[n1])
+    assert n2 in ans
+    _hit_count_eq(e2, ans[n2])
+    assert o.uid in ans
+    _hit_count_eq(expected, ans[o.uid])
+    _hit_count_eq(expected, o.opstate.hit_count)
+
+
+def test_security_rule_hit_count_refresh():
+    name = "foo"
+    elm = _hit_count_elm(
+        name=name,
+        hit_count=1,
+        last_hit_timestamp=21,
+        last_reset_timestamp=22,
+        first_hit_timestamp=23,
+        rule_creation_timestamp=24,
+        rule_modification_timestamp=25,
+    )
+    expected = HitCount(name=name, elm=elm)
+
+    fw, rb = _hit_count_fw_setup(elm)
+    o = SecurityRule(name)
+    rb.add(o)
+
+    assert not o.opstate.hit_count.rule_creation_timestamp
+
+    o.opstate.hit_count.refresh()
+
+    _hit_count_eq(expected, o.opstate.hit_count)


### PR DESCRIPTION
Fixes #239 - Adds `opstate.get_rule_hit_count()` to both the rulebases and
to all supported rule types.
