### PR TITLE
fix: Set Panorama as parent object for Firewalls

### DIFF
--- a/panos/firewall.py
+++ b/panos/firewall.py
@@ -381,6 +381,9 @@ class Firewall(PanDevice):
                         )
                 else:
                     firewall_instances.append(Firewall(serial=entry.get("name")))
+        # Propagate parent to firewall instances
+        for fw in firewall_instances:
+            fw.parent = self.parent
         return firewall_instances
 
     def show_system_resources(self):

--- a/panos/panorama.py
+++ b/panos/panorama.py
@@ -566,6 +566,7 @@ class Panorama(base.PanDevice):
 
         # Create firewall instances
         tmp_fw = self.FIREWALL_CLASS()
+        tmp_fw.parent = self
         firewall_instances = tmp_fw.refreshall_from_xml(
             devices_xml, refresh_children=not expand_vsys
         )


### PR DESCRIPTION
## Description

When refreshing devices from Panorama, Firewall objects need their parent object set.

## Motivation and Context

Attempting to use Firewall objects retrieved via `Panorama.refresh_devices` currently results in a traceback similar to the following:

```
Traceback (most recent call last):
  File "/Users/awilcox/Library/Python/3.8/lib/python/site-packages/pandevice/firewall.py", line 199, in generate_xapi
    self.panorama()
  File "/Users/awilcox/Library/Python/3.8/lib/python/site-packages/pandevice/base.py", line 1030, in panorama
    raise err.PanDeviceNotSet("No Panorama set for object tree")
pandevice.errors.PanDeviceNotSet: No Panorama set for object tree

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/awilcox/Library/Python/3.8/lib/python/site-packages/pandevice/base.py", line 1205, in refreshall
    api_action = device.xapi.show if running_config else device.xapi.get
  File "/Users/awilcox/Library/Python/3.8/lib/python/site-packages/pandevice/base.py", line 3588, in xapi
    self._xapi_private = self.generate_xapi()
  File "/Users/awilcox/Library/Python/3.8/lib/python/site-packages/pandevice/firewall.py", line 201, in generate_xapi
    return super(Firewall, self).generate_xapi()
  File "/Users/awilcox/Library/Python/3.8/lib/python/site-packages/pandevice/base.py", line 3630, in generate_xapi
    kwargs = {'api_key': self.api_key,
  File "/Users/awilcox/Library/Python/3.8/lib/python/site-packages/pandevice/base.py", line 3582, in api_key
    self._api_key = self._retrieve_api_key()
  File "/Users/awilcox/Library/Python/3.8/lib/python/site-packages/pandevice/base.py", line 3708, in _retrieve_api_key
    xapi = PanDevice.XapiWrapper(
  File "/Users/awilcox/Library/Python/3.8/lib/python/site-packages/pandevice/base.py", line 3390, in __init__
    pan.xapi.PanXapi.__init__(self, *args, **kwargs)
  File "/Users/awilcox/Library/Python/3.8/lib/python/site-packages/pan/xapi.py", line 178, in __init__
    raise PanXapiError('hostname argument required')
pan.xapi.PanXapiError: hostname argument required
```

## How Has This Been Tested?

Using the Python REPL and a module that we have written which consumes pandevice.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.  **No**: there did not seem to be a documentation update required.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.  **No**: I found no existing suite for testing the functionality of `refresh_devices` and adding such a test suite is beyond the scope of this otherwise-simple bug fix.
- [x] All new and existing tests passed.
