### PR TITLE
feat: Add PanDevice.whoami()

### DIFF
--- a/panos/base.py
+++ b/panos/base.py
@@ -5293,3 +5293,25 @@ class PanDevice(PanObject):
             )
 
         return ans
+
+    def whoami(self):
+        """Returns which user you're currently authenticated as.
+
+        NOTE:  PAN-OS 10.0+
+
+        Returns:
+            string
+        """
+        res = self.op("<show><admins/></show>", cmd_xml=False)
+
+        for o in res.findall("./result/admins/entry"):
+            name = None
+            is_self = False
+            for child in o:
+                if child.tag == "admin":
+                    name = child.text
+                elif child.tag == "self":
+                    is_self = True
+
+                if name is not None and is_self:
+                    return name

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1371,5 +1371,51 @@ class TestPanDevice(unittest.TestCase):
         self.assertEqual(ad.get("downloaded"), "yes")
 
 
+class TestWhoami(unittest.TestCase):
+    def test_self_is_present(self):
+        expected = "user2"
+        resp = [
+            "<response>",
+            "<result>",
+            "<admins>",
+            "<entry><admin>user1</admin><type>Web</type></entry>",
+            "<entry><admin>{0}</admin><type>Web</type><self/></entry>".format(expected),
+            "</admins>",
+            "</result>",
+            "</response>",
+        ]
+
+        spec = {
+            "return_value": ET.fromstring("".join(resp)),
+        }
+
+        con = Base.PanDevice("127.0.0.1", "a", "b", "c")
+        con.op = mock.Mock(**spec)
+
+        self.assertEqual(expected, con.whoami())
+
+    def test_not_present(self):
+        resp = [
+            "<response>",
+            "<result>",
+            "<admins>",
+            "<entry><admin>user1</admin><type>Web</type></entry>",
+            "<entry><admin>user2</admin><type>Web</type></entry>",
+            "<entry><admin>user3</admin><type>Web</type></entry>",
+            "</admins>",
+            "</result>",
+            "</response>",
+        ]
+
+        spec = {
+            "return_value": ET.fromstring("".join(resp)),
+        }
+
+        con = Base.PanDevice("127.0.0.1", "a", "b", "c")
+        con.op = mock.Mock(**spec)
+
+        self.assertIsNone(con.whoami())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #261 enhancement request.  This adds a convenience method that
checks users that are currently logged in to PAN-OS and returns which
user you are connected as.  This function only works on PAN-OS 10.0+.
