### PR TITLE
feat: Add audit comment support for rules

### DIFF
--- a/panos/policies.py
+++ b/panos/policies.py
@@ -977,14 +977,13 @@ class RuleAuditComment(object):
         query += " and (path contains '\\'{0}\\'')".format(p.vsys)
 
         extra_qs = {
-            "query": query,
             "dir": direction,
             "uniq": "yes",
         }
         if skip is not None:
             extra_qs["skip"] = "{0}".format(int(skip))
 
-        resp = dev.xapi.log("config", count, extra_qs=extra_qs)
+        resp = dev.xapi.log("config", count, filter=query, extra_qs=extra_qs)
 
         return [AuditCommentLog(x) for x in resp.findall("./result/log/logs/entry")]
 

--- a/panos/policies.py
+++ b/panos/policies.py
@@ -863,7 +863,20 @@ class RulebaseHitCount(object):
         return ans
 
 
-class HitCount(object):
+class OpStateObject(object):
+    def _str(self, elm, field):
+        if elm is not None:
+            val = elm.find("./{0}".format(field))
+            if val is not None:
+                return val.text
+
+    def _int(self, elm, field):
+        val = self._str(elm, field)
+        if val is not None:
+            return int(val)
+
+
+class HitCount(OpStateObject):
     """Hit count operational data."""
 
     FIELDS = (
@@ -896,24 +909,118 @@ class HitCount(object):
             else:
                 setattr(self, param, self._str(elm, path))
 
-    def _str(self, elm, field):
-        if elm is None:
-            return
-
-        val = elm.find("./{0}".format(field))
-        if val is not None:
-            return val.text
-
-    def _int(self, elm, field):
-        val = self._str(elm, field)
-
-        if val is not None:
-            return int(val)
-
 
 class RuleOpState(object):
     """Operational state handling for a rule in the rulebase."""
 
     def __init__(self, obj):
         self.obj = obj
+        self.audit_comment = RuleAuditComment(obj)
         self.hit_count = HitCount(obj)
+
+
+class RuleAuditComment(object):
+    """Operational state handling for a rule's audit comments.
+
+    Note:  Audit comments are present in PAN-OS 9.0+.
+
+    """
+
+    def __init__(self, obj):
+        self.obj = obj
+
+    def history(self, count=100, direction="backward", skip=None):
+        """Returns a chunk of historical audit comment logs.
+
+        Args:
+            count (int): Number of audit comments to return, maximum 5000.
+            direction (str): Specify whether logs are shown oldest first
+                (``forward``) or newest first (``backward``).
+            skip (int): Specify the number of logs to skip when doing log
+                retrieval.  This is useful when retrieving logs in batches
+                where you can skip the previously retrieved logs.
+
+        Returns:
+            list of :class:`panos.policies.AuditCommentLog`
+
+        """
+        dev = self.obj.nearest_pandevice()
+        xpath = self.obj.xpath()
+
+        # Build up the query.
+        query = "(subtype eq audit-comment)"
+        # Add in the name.
+        query += " and (path contains '\\'{0}\\'')".format(self.obj.uid)
+        # Add in the rule type.
+        query += " and (path contains '{0}')".format(
+            self.obj.xpath_short().split("/")[-2],
+        )
+        # Add in the rulebase type.
+        p = self.obj.parent
+        if p is None:
+            raise err.PanDeviceError("rule has empty parent")
+        if not any(isinstance(p, x) for x in (Rulebase, PreRulebase, PostRulebase)):
+            raise err.PanDeviceError("{0} has non-rulebase parent".format(self.obj.uid))
+        query += " and (path contains {0})".format(p.xpath().split("/")[-1])
+        # Add in the vsys or device group.
+        query += " and (path contains '\\'{0}\\'')".format(p.vsys)
+
+        extra_qs = {
+            "query": query,
+            "dir": direction,
+            "uniq": "yes",
+        }
+        if skip is not None:
+            extra_qs["skip"] = "{0}".format(int(skip))
+
+        resp = dev.xapi.log("config", count, extra_qs=extra_qs)
+
+        return [AuditCommentLog(x) for x in resp.findall("./result/log/logs/entry")]
+
+    def current(self):
+        """Returns the current audit comment.
+
+        Returns:
+            string
+
+        """
+        dev = self.obj.nearest_pandevice()
+        cmd = ET.Element("show")
+        sub = ET.SubElement(cmd, "config")
+        sub = ET.SubElement(sub, "list")
+        sub = ET.SubElement(sub, "audit-comments")
+        ET.SubElement(sub, "xpath").text = self.obj.xpath()
+
+        ans = self.obj.nearest_pandevice().op(
+            ET.tostring(cmd, encoding="utf-8"), cmd_xml=False,
+        )
+
+        resp = ans.find("./result/entry/comment")
+        if resp is not None:
+            return resp.text
+
+    def update(self, comment):
+        """Sets an audit comment for the given rule.
+
+        Args:
+            comment (str): The audit comment.
+
+        """
+        cmd = ET.Element("set")
+        sub = ET.SubElement(cmd, "audit-comment")
+        ET.SubElement(sub, "xpath").text = self.obj.xpath()
+        ET.SubElement(sub, "comment").text = comment
+
+        self.obj.nearest_pandevice().op(
+            ET.tostring(cmd, encoding="utf-8"), cmd_xml=False,
+        )
+
+
+class AuditCommentLog(OpStateObject):
+    """A single audit comment log entry."""
+
+    def __init__(self, elm):
+        self.admin = self._str(elm, "admin")
+        self.comment = self._str(elm, "comment")
+        self.config_version = self._int(elm, "config_ver")
+        self.time = self._str(elm, "time_generated")

--- a/panos/policies.py
+++ b/panos/policies.py
@@ -18,6 +18,7 @@
 """Policies module contains policies and rules that exist in the 'Policies' tab in the firewall GUI"""
 
 import xml.etree.ElementTree as ET
+from datetime import datetime
 
 import panos.errors as err
 from panos import getlogger
@@ -864,6 +865,8 @@ class RulebaseHitCount(object):
 
 
 class OpStateObject(object):
+    """A container object for opstate data."""
+
     def _str(self, elm, field):
         if elm is not None:
             val = elm.find("./{0}".format(field))
@@ -874,6 +877,15 @@ class OpStateObject(object):
         val = self._str(elm, field)
         if val is not None:
             return int(val)
+
+    def _datetime(self, elm, field, fmt):
+        val = self._str(elm, field)
+        if val is not None:
+            try:
+                return datetime.strptime(val, fmt)
+            except ValueError:
+                pass
+            return val
 
 
 class HitCount(OpStateObject):
@@ -945,7 +957,6 @@ class RuleAuditComment(object):
 
         """
         dev = self.obj.nearest_pandevice()
-        xpath = self.obj.xpath()
 
         # Build up the query.
         query = "(subtype eq audit-comment)"
@@ -984,7 +995,6 @@ class RuleAuditComment(object):
             string
 
         """
-        dev = self.obj.nearest_pandevice()
         cmd = ET.Element("show")
         sub = ET.SubElement(cmd, "config")
         sub = ET.SubElement(sub, "list")
@@ -1023,4 +1033,4 @@ class AuditCommentLog(OpStateObject):
         self.admin = self._str(elm, "admin")
         self.comment = self._str(elm, "comment")
         self.config_version = self._int(elm, "config_ver")
-        self.time = self._str(elm, "time_generated")
+        self.time = self._datetime(elm, "time_generated", "%Y/%m/%d %H:%M:%S")

--- a/tests/test_opstate.py
+++ b/tests/test_opstate.py
@@ -9,6 +9,7 @@ from panos.firewall import Firewall
 from panos.policies import HitCount
 from panos.policies import Rulebase
 from panos.policies import SecurityRule
+from panos.policies import AuditCommentLog
 
 
 HIT_COUNT_PREFIX = """
@@ -34,9 +35,14 @@ HIT_COUNT_SUFFIX = """
 """
 
 
-def _hit_count_fw_setup(*args):
+def _fw():
     fw = Firewall("127.0.0.1", "admin", "admin", "secret")
     fw._version_info = (9999, 0, 0)
+    return fw
+
+
+def _hit_count_fw_setup(*args):
+    fw = _fw()
 
     inner = "".join(ET.tostring(x, encoding="utf-8").decode("utf-8") for x in args)
 
@@ -238,3 +244,140 @@ def test_security_rule_hit_count_refresh():
     o.opstate.hit_count.refresh()
 
     _hit_count_eq(expected, o.opstate.hit_count)
+
+
+def test_current_audit_comment():
+    expected = "Hello, world"
+
+    fw = _fw()
+    rb = Rulebase()
+    fw.add(rb)
+    obj = SecurityRule("foo")
+    rb.add(obj)
+    fw.op = mock.Mock(
+        return_value=ET.fromstring(
+            "\n".join(
+                [
+                    "<response>",
+                    "<result>",
+                    "<entry>",
+                    "<xpath>{0}</xpath>".format(obj.xpath()),
+                    "<dirtyId>17</dirtyId>",
+                    "<comment>{0}</comment>".format(expected),
+                    "<prevdirtyId>0</prevdirtyId>",
+                    "</entry>",
+                    "</result>",
+                    "</response>",
+                ]
+            ),
+        ),
+    )
+
+    assert expected == obj.opstate.audit_comment.current()
+
+
+def test_audit_comment_history():
+    fw = _fw()
+    rb = Rulebase()
+    fw.add(rb)
+    obj = SecurityRule("my policy")
+    rb.add(obj)
+    fw.xapi.log = mock.Mock(
+        return_value=ET.fromstring(
+            """
+<response status="success"><result>
+  <job>
+    <tenq>10:28:38</tenq>
+    <tdeq>10:28:38</tdeq>
+    <tlast>10:28:38</tlast>
+    <status>FIN</status>
+    <id>729</id>
+  </job>
+  <log>
+    <logs count="2" progress="100">
+      <entry logid="6947456634637516808">
+        <domain>1</domain>
+        <receive_time>2021/04/05 15:21:50</receive_time>
+        <serial>unknown</serial>
+        <seqno>2306</seqno>
+        <actionflags>0x0</actionflags>
+        <is-logging-service>no</is-logging-service>
+        <type>CONFIG</type>
+        <subtype>1</subtype>
+        <config_ver>16</config_ver>
+        <time_generated>2021/04/05 15:21:50</time_generated>
+        <dg_hier_level_1>0</dg_hier_level_1>
+        <dg_hier_level_2>0</dg_hier_level_2>
+        <dg_hier_level_3>0</dg_hier_level_3>
+        <dg_hier_level_4>0</dg_hier_level_4>
+        <device_name>PA-VM</device_name>
+        <vsys_id>0</vsys_id>
+        <host>174.87.104.22</host>
+        <cmd>audit-commit</cmd>
+        <admin>admin1</admin>
+        <client>Web</client>
+        <result>Succeeded</result>
+        <path> vsys  vsys1 rulebase security rules  my policy</path>
+        <dg_id>0</dg_id>
+        <comment>newest comment</comment>
+        <before-change-preview>d0c5e58b-63d1-475b-a9b3-25f169ee296e</before-change-preview>
+        <after-change-preview>d0c5e58b-63d1-475b-a9b3-25f169ee296e</after-change-preview>
+        <full-path>/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/rulebase/security/rules/entry[@name='my policy']</full-path>
+      </entry>
+      <entry logid="6947456634637516805">
+        <domain>1</domain>
+        <receive_time>2021/04/05 14:57:40</receive_time>
+        <serial>unknown</serial>
+        <seqno>2303</seqno>
+        <actionflags>0x0</actionflags>
+        <is-logging-service>no</is-logging-service>
+        <type>CONFIG</type>
+        <subtype>1</subtype>
+        <config_ver>15</config_ver>
+        <time_generated>2021/04/05 14:57:40</time_generated>
+        <dg_hier_level_1>0</dg_hier_level_1>
+        <dg_hier_level_2>0</dg_hier_level_2>
+        <dg_hier_level_3>0</dg_hier_level_3>
+        <dg_hier_level_4>0</dg_hier_level_4>
+        <device_name>PA-VM</device_name>
+        <vsys_id>0</vsys_id>
+        <host>174.87.104.22</host>
+        <cmd>audit-commit</cmd>
+        <admin>admin2</admin>
+        <client>Web</client>
+        <result>Succeeded</result>
+        <path> vsys  vsys1 rulebase security rules  my policy</path>
+        <dg_id>0</dg_id>
+        <comment>initial comment</comment>
+        <before-change-preview>d0c5e58b-63d1-475b-a9b3-25f169ee296e</before-change-preview>
+        <after-change-preview>d0c5e58b-63d1-475b-a9b3-25f169ee296e</after-change-preview>
+        <full-path>/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/rulebase/security/rules/entry[@name='my policy']</full-path>
+      </entry>
+    </logs>
+  </log>
+  <meta>
+    <devices>
+      <entry name="localhost.localdomain">
+        <hostname>localhost.localdomain</hostname>
+        <vsys>
+          <entry name="vsys1">
+            <display-name>vsys1</display-name>
+          </entry>
+        </vsys>
+      </entry>
+    </devices>
+  </meta>
+</result></response>
+        """
+        ),
+    )
+
+    ans = obj.opstate.audit_comment.history()
+
+    assert len(ans) == 2
+    assert ans[0].admin == "admin1"
+    assert ans[0].comment == "newest comment"
+    assert ans[0].config_version == 16
+    assert ans[1].admin == "admin2"
+    assert ans[1].comment == "initial comment"
+    assert ans[1].config_version == 15

--- a/tests/test_opstate.py
+++ b/tests/test_opstate.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import xml.etree.ElementTree as ET
 
 try:
@@ -371,6 +372,8 @@ def test_audit_comment_history():
         """
         ),
     )
+    t1 = datetime(2021, 4, 5, 15, 21, 50)
+    t2 = datetime(2021, 4, 5, 14, 57, 40)
 
     ans = obj.opstate.audit_comment.history()
 
@@ -378,6 +381,8 @@ def test_audit_comment_history():
     assert ans[0].admin == "admin1"
     assert ans[0].comment == "newest comment"
     assert ans[0].config_version == 16
+    assert ans[0].time == t1
     assert ans[1].admin == "admin2"
     assert ans[1].comment == "initial comment"
     assert ans[1].config_version == 15
+    assert ans[1].time == t2


### PR DESCRIPTION
This adds an `audit_comment` namespace onto all rules in the
`policies` library.  Also adds a few new unittests for the XML
returned from the XML API.

Fixes #272
Fixes #209
