### PR TITLE
fix: Correcting profile xpaths

### DIFF
--- a/panos/base.py
+++ b/panos/base.py
@@ -40,7 +40,7 @@ from panos import isstring, string_or_list, updater, userid, yesno
 
 logger = panos.getlogger(__name__)
 
-Root = panos.enum("DEVICE", "VSYS", "MGTCONFIG")
+Root = panos.enum("DEVICE", "VSYS", "MGTCONFIG", "PANORAMA", "PANORAMA_VSYS")
 SELF = "/%s"
 ENTRY = "/entry[@name='%s']"
 MEMBER = "/member[text()='%s']"
@@ -310,6 +310,13 @@ class PanObject(object):
                 # Stop on the first pandevice encountered, unless the
                 # panos.PanDevice object is the object whose xpath
                 # was asked for.
+                # If the object whose xpath we are creating is directly
+                # attached to a Panorama and the root is PANORAMA
+                if root == Root.PANORAMA_VSYS:
+                    if p.__class__.__name__ == "Panorama":
+                        root = Root.PANORAMA
+                    else:
+                        root = Root.VSYS
                 path.insert(0, p.xpath_root(root, vsys, label))
                 break
             elif p.__class__.__name__ == "Predefined":
@@ -339,6 +346,8 @@ class PanObject(object):
                     # Hit a template, make sure that the appropriate /config/...
                     # xpath has been saved.
                     if not path[0].startswith("/config/"):
+                        if root == Root.PANORAMA_VSYS:
+                            root = Root.VSYS
                         path.insert(0, self.xpath_root(root, vsys, label))
                     vsys = p.vsys
                     root = p.ROOT

--- a/panos/device.py
+++ b/panos/device.py
@@ -867,7 +867,7 @@ class SnmpServerProfile(VersionedPanObject):
 
     """
 
-    ROOT = Root.VSYS
+    ROOT = Root.PANORAMA_VSYS
     SUFFIX = ENTRY
     CHILDTYPES = (
         "device.SnmpV2cServer",
@@ -900,7 +900,7 @@ class SnmpV2cServer(VersionedPanObject):
 
     """
 
-    ROOT = Root.VSYS
+    ROOT = Root.PANORAMA_VSYS
     SUFFIX = ENTRY
 
     def _setup(self):
@@ -929,7 +929,7 @@ class SnmpV3Server(VersionedPanObject):
 
     """
 
-    ROOT = Root.VSYS
+    ROOT = Root.PANORAMA_VSYS
     SUFFIX = ENTRY
 
     def _setup(self):
@@ -976,7 +976,7 @@ class EmailServerProfile(VersionedPanObject):
 
     """
 
-    ROOT = Root.VSYS
+    ROOT = Root.PANORAMA_VSYS
     SUFFIX = ENTRY
     CHILDTYPES = ("device.EmailServer",)
 
@@ -1033,7 +1033,7 @@ class EmailServer(VersionedPanObject):
 
     """
 
-    ROOT = Root.VSYS
+    ROOT = Root.PANORAMA_VSYS
     SUFFIX = ENTRY
 
     def _setup(self):
@@ -1076,7 +1076,7 @@ class SyslogServerProfile(VersionedPanObject):
 
     """
 
-    ROOT = Root.VSYS
+    ROOT = Root.PANORAMA_VSYS
     SUFFIX = ENTRY
     CHILDTYPES = ("device.SyslogServer",)
 
@@ -1136,7 +1136,7 @@ class SyslogServer(VersionedPanObject):
 
     """
 
-    ROOT = Root.VSYS
+    ROOT = Root.PANORAMA_VSYS
     SUFFIX = ENTRY
 
     def _setup(self):
@@ -1227,7 +1227,7 @@ class HttpServerProfile(VersionedPanObject):
 
     """
 
-    ROOT = Root.VSYS
+    ROOT = Root.PANORAMA_VSYS
     SUFFIX = ENTRY
     CHILDTYPES = (
         "device.HttpServer",
@@ -1387,7 +1387,7 @@ class HttpServer(VersionedPanObject):
 
     """
 
-    ROOT = Root.VSYS
+    ROOT = Root.PANORAMA_VSYS
     SUFFIX = ENTRY
 
     def _setup(self):
@@ -1435,6 +1435,7 @@ class HttpConfigHeader(ValueEntry):
     """
 
     LOCATION = "/format/config/headers"
+    ROOT = Root.PANORAMA_VSYS
 
 
 class HttpConfigParam(ValueEntry):
@@ -1449,6 +1450,7 @@ class HttpConfigParam(ValueEntry):
     """
 
     LOCATION = "/format/config/params"
+    ROOT = Root.PANORAMA_VSYS
 
 
 class HttpSystemHeader(ValueEntry):
@@ -1463,6 +1465,7 @@ class HttpSystemHeader(ValueEntry):
     """
 
     LOCATION = "/format/system/headers"
+    ROOT = Root.PANORAMA_VSYS
 
 
 class HttpSystemParam(ValueEntry):
@@ -1477,6 +1480,7 @@ class HttpSystemParam(ValueEntry):
     """
 
     LOCATION = "/format/system/params"
+    ROOT = Root.PANORAMA_VSYS
 
 
 class HttpThreatHeader(ValueEntry):
@@ -1491,6 +1495,7 @@ class HttpThreatHeader(ValueEntry):
     """
 
     LOCATION = "/format/threat/headers"
+    ROOT = Root.PANORAMA_VSYS
 
 
 class HttpThreatParam(ValueEntry):
@@ -1505,6 +1510,7 @@ class HttpThreatParam(ValueEntry):
     """
 
     LOCATION = "/format/threat/params"
+    ROOT = Root.PANORAMA_VSYS
 
 
 class HttpTrafficHeader(ValueEntry):
@@ -1519,6 +1525,7 @@ class HttpTrafficHeader(ValueEntry):
     """
 
     LOCATION = "/format/traffic/headers"
+    ROOT = Root.PANORAMA_VSYS
 
 
 class HttpTrafficParam(ValueEntry):
@@ -1533,6 +1540,7 @@ class HttpTrafficParam(ValueEntry):
     """
 
     LOCATION = "/format/traffic/params"
+    ROOT = Root.PANORAMA_VSYS
 
 
 class HttpHipMatchHeader(ValueEntry):
@@ -1547,6 +1555,7 @@ class HttpHipMatchHeader(ValueEntry):
     """
 
     LOCATION = "/format/hip-match/headers"
+    ROOT = Root.PANORAMA_VSYS
 
 
 class HttpHipMatchParam(ValueEntry):
@@ -1561,6 +1570,7 @@ class HttpHipMatchParam(ValueEntry):
     """
 
     LOCATION = "/format/hip-match/params"
+    ROOT = Root.PANORAMA_VSYS
 
 
 class HttpUrlHeader(ValueEntry):
@@ -1575,6 +1585,7 @@ class HttpUrlHeader(ValueEntry):
     """
 
     LOCATION = "/format/url/headers"
+    ROOT = Root.PANORAMA_VSYS
 
 
 class HttpUrlParam(ValueEntry):
@@ -1589,6 +1600,7 @@ class HttpUrlParam(ValueEntry):
     """
 
     LOCATION = "/format/url/params"
+    ROOT = Root.PANORAMA_VSYS
 
 
 class HttpDataHeader(ValueEntry):
@@ -1603,6 +1615,7 @@ class HttpDataHeader(ValueEntry):
     """
 
     LOCATION = "/format/data/headers"
+    ROOT = Root.PANORAMA_VSYS
 
 
 class HttpDataParam(ValueEntry):
@@ -1617,6 +1630,7 @@ class HttpDataParam(ValueEntry):
     """
 
     LOCATION = "/format/data/params"
+    ROOT = Root.PANORAMA_VSYS
 
 
 class HttpWildfireHeader(ValueEntry):
@@ -1631,6 +1645,7 @@ class HttpWildfireHeader(ValueEntry):
     """
 
     LOCATION = "/format/wildfire/headers"
+    ROOT = Root.PANORAMA_VSYS
 
 
 class HttpWildfireParam(ValueEntry):
@@ -1645,6 +1660,7 @@ class HttpWildfireParam(ValueEntry):
     """
 
     LOCATION = "/format/wildfire/params"
+    ROOT = Root.PANORAMA_VSYS
 
 
 class HttpTunnelHeader(ValueEntry):
@@ -1659,6 +1675,7 @@ class HttpTunnelHeader(ValueEntry):
     """
 
     LOCATION = "/format/tunnel/headers"
+    ROOT = Root.PANORAMA_VSYS
 
 
 class HttpTunnelParam(ValueEntry):
@@ -1673,6 +1690,7 @@ class HttpTunnelParam(ValueEntry):
     """
 
     LOCATION = "/format/tunnel/params"
+    ROOT = Root.PANORAMA_VSYS
 
 
 class HttpUserIdHeader(ValueEntry):
@@ -1687,6 +1705,7 @@ class HttpUserIdHeader(ValueEntry):
     """
 
     LOCATION = "/format/userid/headers"
+    ROOT = Root.PANORAMA_VSYS
 
 
 class HttpUserIdParam(ValueEntry):
@@ -1701,6 +1720,7 @@ class HttpUserIdParam(ValueEntry):
     """
 
     LOCATION = "/format/userid/params"
+    ROOT = Root.PANORAMA_VSYS
 
 
 class HttpGtpHeader(ValueEntry):
@@ -1715,6 +1735,7 @@ class HttpGtpHeader(ValueEntry):
     """
 
     LOCATION = "/format/gtp/headers"
+    ROOT = Root.PANORAMA_VSYS
 
 
 class HttpGtpParam(ValueEntry):
@@ -1729,6 +1750,7 @@ class HttpGtpParam(ValueEntry):
     """
 
     LOCATION = "/format/gtp/params"
+    ROOT = Root.PANORAMA_VSYS
 
 
 class HttpAuthHeader(ValueEntry):
@@ -1743,6 +1765,7 @@ class HttpAuthHeader(ValueEntry):
     """
 
     LOCATION = "/format/auth/headers"
+    ROOT = Root.PANORAMA_VSYS
 
 
 class HttpAuthParam(ValueEntry):
@@ -1757,6 +1780,7 @@ class HttpAuthParam(ValueEntry):
     """
 
     LOCATION = "/format/auth/params"
+    ROOT = Root.PANORAMA_VSYS
 
 
 class HttpSctpHeader(ValueEntry):
@@ -1771,6 +1795,7 @@ class HttpSctpHeader(ValueEntry):
     """
 
     LOCATION = "/format/sctp/headers"
+    ROOT = Root.PANORAMA_VSYS
 
 
 class HttpSctpParam(ValueEntry):
@@ -1785,6 +1810,7 @@ class HttpSctpParam(ValueEntry):
     """
 
     LOCATION = "/format/sctp/params"
+    ROOT = Root.PANORAMA_VSYS
 
 
 class HttpIpTagHeader(ValueEntry):
@@ -1799,6 +1825,7 @@ class HttpIpTagHeader(ValueEntry):
     """
 
     LOCATION = "/format/iptag/headers"
+    ROOT = Root.PANORAMA_VSYS
 
 
 class HttpIpTagParam(ValueEntry):
@@ -1813,3 +1840,4 @@ class HttpIpTagParam(ValueEntry):
     """
 
     LOCATION = "/format/iptag/params"
+    ROOT = Root.PANORAMA_VSYS

--- a/tests/test_device_profile_xpaths.py
+++ b/tests/test_device_profile_xpaths.py
@@ -1,0 +1,239 @@
+import xml.etree.ElementTree as ET
+
+import pytest
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from panos.device import SnmpServerProfile
+from panos.device import SnmpV2cServer
+from panos.device import SnmpV3Server
+
+from panos.device import EmailServerProfile
+from panos.device import EmailServer
+
+from panos.device import SyslogServerProfile
+from panos.device import SyslogServer
+
+from panos.device import HttpServerProfile
+from panos.device import HttpServer
+from panos.device import HttpConfigHeader
+from panos.device import HttpConfigParam
+from panos.device import HttpSystemHeader
+from panos.device import HttpSystemParam
+from panos.device import HttpThreatHeader
+from panos.device import HttpThreatParam
+from panos.device import HttpTrafficHeader
+from panos.device import HttpTrafficParam
+from panos.device import HttpHipMatchHeader
+from panos.device import HttpHipMatchParam
+from panos.device import HttpUrlHeader
+from panos.device import HttpUrlParam
+from panos.device import HttpDataHeader
+from panos.device import HttpDataParam
+from panos.device import HttpWildfireHeader
+from panos.device import HttpWildfireParam
+from panos.device import HttpTunnelHeader
+from panos.device import HttpTunnelParam
+from panos.device import HttpUserIdHeader
+from panos.device import HttpUserIdParam
+from panos.device import HttpGtpHeader
+from panos.device import HttpGtpParam
+from panos.device import HttpAuthHeader
+from panos.device import HttpAuthParam
+from panos.device import HttpSctpHeader
+from panos.device import HttpSctpParam
+from panos.device import HttpIpTagHeader
+from panos.device import HttpIpTagParam
+
+from panos.firewall import Firewall
+from panos.device import Vsys
+
+from panos.panorama import Panorama
+from panos.panorama import Template
+
+
+OBJECTS = {
+    SnmpServerProfile: [None, SnmpV2cServer, SnmpV3Server],
+    EmailServerProfile: [None, EmailServer,],
+    SyslogServerProfile: [None, SyslogServer,],
+    HttpServerProfile: [
+        None,
+        HttpServer,
+        HttpConfigHeader,
+        HttpConfigParam,
+        HttpSystemHeader,
+        HttpSystemParam,
+        HttpThreatHeader,
+        HttpThreatParam,
+        HttpTrafficHeader,
+        HttpTrafficParam,
+        HttpHipMatchHeader,
+        HttpHipMatchParam,
+        HttpUrlHeader,
+        HttpUrlParam,
+        HttpDataHeader,
+        HttpDataParam,
+        HttpWildfireHeader,
+        HttpWildfireParam,
+        HttpTunnelHeader,
+        HttpTunnelParam,
+        HttpUserIdHeader,
+        HttpUserIdParam,
+        HttpGtpHeader,
+        HttpGtpParam,
+        HttpAuthHeader,
+        HttpAuthParam,
+        HttpSctpHeader,
+        HttpSctpParam,
+        HttpIpTagHeader,
+        HttpIpTagParam,
+    ],
+}
+
+"""
+@pytest.fixture(
+    scope="function",
+    params=[x for x in DEVICES],
+    ids=[x.__class__.__name__ for x in DEVICES],
+)
+def pdev(request):
+    request.param.removeall()
+    return request.param
+"""
+
+
+@pytest.fixture(
+    scope="function",
+    params=[(x, y) for x, v in OBJECTS.items() for y in v],
+    ids=[
+        "{0}{1}".format(x.__class__.__name__, y.__class__.__name__ if y else "None")
+        for x, v in OBJECTS.items()
+        for y in v
+    ],
+)
+def combination(request):
+    return request.param
+
+
+def test_firewall_shared_xpath(combination):
+    expected = [
+        "/config/shared",
+    ]
+    fw = Firewall("127.0.0.1", "admin", "admin", "secret")
+    fw._version_info = (9999, 0, 0)
+    fw.vsys = "shared"
+    parent_cls, child_cls = combination
+
+    o = parent_cls("one")
+    expected.append(o.xpath())
+    if child_cls is not None:
+        o2 = child_cls("two")
+        expected.append(o2.xpath())
+        o.add(o2)
+        o = o2
+        fw.add(o.parent)
+    else:
+        fw.add(o)
+
+    assert "".join(expected) == o.xpath()
+
+
+def test_firewall_vsys_xpath(combination):
+    expected = [
+        "/config/devices/entry[@name='localhost.localdomain']",
+        "/vsys/entry[@name='vsys1']",
+    ]
+    fw = Firewall("127.0.0.1", "admin", "admin", "secret")
+    fw._version_info = (9999, 0, 0)
+    parent_cls, child_cls = combination
+
+    o = parent_cls("one")
+    expected.append(o.xpath())
+    if child_cls is not None:
+        o2 = child_cls("two")
+        expected.append(o2.xpath())
+        o.add(o2)
+        o = o2
+        fw.add(o.parent)
+    else:
+        fw.add(o)
+
+    assert "".join(expected) == o.xpath()
+
+
+def test_firewall_vsys_object_xpath(combination):
+    expected = [
+        "/config/devices/entry[@name='localhost.localdomain']",
+        "/vsys/entry[@name='vsys2']",
+    ]
+    fw = Firewall("127.0.0.1", "admin", "admin", "secret")
+    fw._version_info = (9999, 0, 0)
+    vsys = Vsys("vsys2")
+    fw.add(vsys)
+    parent_cls, child_cls = combination
+
+    o = parent_cls("one")
+    expected.append(o.xpath())
+    if child_cls is not None:
+        o2 = child_cls("two")
+        expected.append(o2.xpath())
+        o.add(o2)
+        o = o2
+        vsys.add(o.parent)
+    else:
+        vsys.add(o)
+
+    assert "".join(expected) == o.xpath()
+
+
+def test_panorama_template_object_xpath(combination):
+    expected = [
+        "/config/devices/entry[@name='localhost.localdomain']",
+    ]
+    pano = Panorama("127.0.0.1", "admin", "admin", "secret")
+    pano._version_info = (9999, 0, 0)
+    tmpl = Template("myTemplate")
+    expected.append(tmpl.xpath())
+    pano.add(tmpl)
+    expected.append("/config/shared")
+    vsys = Vsys("shared")
+    tmpl.add(vsys)
+    parent_cls, child_cls = combination
+
+    o = parent_cls("one")
+    expected.append(o.xpath())
+    if child_cls is not None:
+        o2 = child_cls("two")
+        expected.append(o2.xpath())
+        o.add(o2)
+        o = o2
+        vsys.add(o.parent)
+    else:
+        vsys.add(o)
+
+    assert "".join(expected) == o.xpath()
+
+
+def test_panorama_local_object_xpath(combination):
+    expected = [
+        "/config/panorama",
+    ]
+    pano = Panorama("127.0.0.1", "admin", "admin", "secret")
+    pano._version_info = (9999, 0, 0)
+    parent_cls, child_cls = combination
+
+    o = parent_cls("one")
+    expected.append(o.xpath())
+    if child_cls is not None:
+        o2 = child_cls("two")
+        expected.append(o2.xpath())
+        o.add(o2)
+        o = o2
+        pano.add(o.parent)
+    else:
+        pano.add(o)
+
+    assert "".join(expected) == o.xpath()


### PR DESCRIPTION
This fixes #266.  The correct XPATH for profiles when directly configured
in Panorama is /config/panorama not /config/shared.  To support this, a new
object ROOT was created: PANORAMA_VSYS, which allows a fallback ROOT of VSYS,
but will otherwise be /config/panorama if the object is directly connected to
a Panorama PanDevice object.