### PR TITLE
feature Ldap server profile

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,6 +27,5 @@
     "pandevice",
     "pan-os-python",
     "refreshall"
-  ],
-  "python.pythonPath": "/home/kevin/.pyenv/versions/dev-panos/envs/panos-featured/bin/python"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,5 +27,6 @@
     "pandevice",
     "pan-os-python",
     "refreshall"
-  ]
+  ],
+  "python.pythonPath": "/home/kevin/.pyenv/versions/dev-panos/envs/panos-featured/bin/python"
 }

--- a/panos/device.py
+++ b/panos/device.py
@@ -114,6 +114,7 @@ class Vsys(VersionedPanObject):
         "device.VsysResources",
         "device.SnmpServerProfile",
         "device.EmailServerProfile",
+        "device.LdapServerProfile",
         "device.SyslogServerProfile",
         "device.HttpServerProfile",
         "objects.AddressObject",
@@ -1050,6 +1051,101 @@ class EmailServer(VersionedPanObject):
         params.append(VersionedParamPath("email_gateway", path="gateway"))
 
         self._params = tuple(params)
+
+
+class LdapServerProfile(VersionedPanObject):
+    """An ldap server profile.
+
+    Args:
+        name (str): The name
+        ldap_type: Ldap profile type. Valid values are "other" (default),
+            "active-directory", "e-directory", or "sun".
+        base(str): Base DN
+        bind_dn (str): Bind DN
+        bind_password (str): Bind password
+        bind_timelimit (int): Bind timeout
+        timelimit (int): Search timeout
+        retry_interval (int): Retry interval
+        ssl (bool): Require ssl/ttls secured connection
+        verify_server_certificate (bool): Verify server certificate for ssl sessions
+
+    """
+
+    ROOT = Root.PANORAMA_VSYS
+    SUFFIX = ENTRY
+    CHILDTYPES = ("device.LdapServer",)
+
+    def _setup(self):
+        # xpaths
+        self._xpaths.add_profile(value="/server-profile/ldap")
+
+        # params
+        params = []
+
+        params.append(
+            VersionedParamPath(
+                "ldap_type",
+                default="other",
+                path="ldap-type",
+                values=["other", "active-directory", "e-directory", "sun"],
+            )
+        )
+        params.append(VersionedParamPath("base", path="base"))
+        params.append(VersionedParamPath("bind_dn", path="bind-dn"))
+        params.append(VersionedParamPath("bind_password", path="bind-password"))
+        params.append(
+            VersionedParamPath(
+                "bind_timelimit", default="30", vartype="int", path="bind-timelimit"
+            )
+        )
+        params.append(
+            VersionedParamPath(
+                "timelimit", default="30", vartype="int", path="timelimit"
+            )
+        )
+        params.append(
+            VersionedParamPath(
+                "retry_interval", default="60", vartype="int", path="retry-interval"
+            )
+        )
+        params.append(VersionedParamPath("ssl", vartype="yesno", path="ssl"))
+        params.append(
+            VersionedParamPath(
+                "verify_server_certificate",
+                condition={"ssl": True},
+                vartype="yesno",
+                path="verify-server-certificate",
+            )
+        )
+
+        self._params = tuple(params)
+
+
+class LdapServer(VersionedPanObject):
+    """An ldap server in a ldap server profile
+
+    Args:
+        name (str): The name
+        address (str): IP address or FQDN of ldap server to use
+        port (str): port number
+
+    """
+
+    ROOT = Root.PANORAMA_VSYS
+    SUFFIX = ENTRY
+
+    def _setup(self):
+        # xpaths
+        self._xpaths.add_profile(value="/server")
+
+        # params
+        params = []
+
+        params.append(VersionedParamPath("address", path="address"))
+        params.append(VersionedParamPath("port", vartype="int", path="port"))
+
+        self._params = tuple(params)
+
 
 
 class SyslogServerProfile(VersionedPanObject):

--- a/panos/device.py
+++ b/panos/device.py
@@ -1147,6 +1147,7 @@ class LdapServer(VersionedPanObject):
         self._params = tuple(params)
 
 
+
 class SyslogServerProfile(VersionedPanObject):
     """A syslog server profile.
 

--- a/panos/device.py
+++ b/panos/device.py
@@ -1147,7 +1147,6 @@ class LdapServer(VersionedPanObject):
         self._params = tuple(params)
 
 
-
 class SyslogServerProfile(VersionedPanObject):
     """A syslog server profile.
 

--- a/panos/firewall.py
+++ b/panos/firewall.py
@@ -67,6 +67,7 @@ class Firewall(PanDevice):
         "device.Telemetry",
         "device.SnmpServerProfile",
         "device.EmailServerProfile",
+        "device.LdapServerProfile",
         "device.SyslogServerProfile",
         "device.HttpServerProfile",
         "ha.HighAvailability",

--- a/panos/panorama.py
+++ b/panos/panorama.py
@@ -381,6 +381,7 @@ class Panorama(base.PanDevice):
         "device.PasswordProfile",
         "device.SnmpServerProfile",
         "device.EmailServerProfile",
+        "device.LdapServerProfile",
         "device.SyslogServerProfile",
         "device.HttpServerProfile",
         "firewall.Firewall",

--- a/tests/test_device_profile_xpaths.py
+++ b/tests/test_device_profile_xpaths.py
@@ -14,6 +14,9 @@ from panos.device import SnmpV3Server
 from panos.device import EmailServerProfile
 from panos.device import EmailServer
 
+from panos.device import LdapServerProfile
+from panos.device import LdapServer
+
 from panos.device import SyslogServerProfile
 from panos.device import SyslogServer
 
@@ -58,6 +61,7 @@ from panos.panorama import Template
 OBJECTS = {
     SnmpServerProfile: [None, SnmpV2cServer, SnmpV3Server],
     EmailServerProfile: [None, EmailServer,],
+    LdapServerProfile: [None, LdapServer,],
     SyslogServerProfile: [None, SyslogServer,],
     HttpServerProfile: [
         None,


### PR DESCRIPTION
## Description

Add new functionality Ldap server profile.
This is done by adding two new class (LdapServerProfile and LdapServer) in device.py.


## Motivation and Context

adds a new functionality.

## How Has This Been Tested?

This has been tested on panorama and physical firewall 5220 on version 9.0.10 with python 3.8
below result from panorama.

```
+          config {
+            shared {
+              server-profile {
+                ldap {
+                  myldapProfil {
+                    ldap-type sun;
+                    base "DC=Mycompany, DC=Com";
+                    bind-dn user@mycompany.com;
+                    bind-password -AQ==kd/Z3bQZiv/FwZTNjObTOP3kcOI=dFNrnYwFGIWTS1aV4NWRaQ==;
+                    bind-timelimit 30;
+                    timelimit 30;
+                    retry-interval 70;
+                    ssl yes;
+                    verify-server-certificate yes;
+                    server {
+                      server1 {
+                        address 1.1.1.1;
+                        port 1389;
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
```
## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes if appropriate.
- [X] All new and existing tests passed.
