### PR TITLE
add feat logsettings system and config

### DIFF
--- a/panos/device.py
+++ b/panos/device.py
@@ -371,6 +371,114 @@ class SystemSettings(VersionedPanObject):
         self._params = tuple(params)
 
 
+class LogSettingsSystem(VersionedPanObject):
+    """Firewall or Panorama device log settings system
+
+    Args:
+        name (string): The name
+        filter (string): Valid values are "All logs" (default) or create your own filter
+        description (string): Description
+        send_to_panorama (bool): Send to panorama
+        send_email (string): Send email profile
+        send_snmp (string): Send snmp profile
+        send_syslog (string): Send syslog profile
+        send_http (string): Send http profile
+
+    """
+
+    ROOT = Root.VSYS
+    SUFFIX = ENTRY
+
+    def _setup(self):
+        # xpaths
+        self._xpaths.add_profile(value="/log-settings/system/match-list")
+
+        # params
+        params = []
+
+        params.append(VersionedParamPath("filter", default="All Logs", path="filter"))
+
+        params.append(VersionedParamPath("description", path="description"))
+
+        params.append(
+            VersionedParamPath(
+                "send_to_panorama", vartype="yesno", path="send-to-panorama"
+            )
+        )
+
+        params.append(
+            VersionedParamPath("send_email", vartype="member", path="send-email")
+        )
+
+        params.append(
+            VersionedParamPath("send_snmp", vartype="member", path="send-snmptrap")
+        )
+
+        params.append(
+            VersionedParamPath("send_syslog", vartype="member", path="send-syslog")
+        )
+
+        params.append(
+            VersionedParamPath("send_http", vartype="member", path="send-http")
+        )
+
+        self._params = tuple(params)
+
+
+class LogSettingsConfig(VersionedPanObject):
+    """Firewall or Panorama device log settings configuration
+
+    Args:
+        name (string): The name
+        filter (string): Valid values are "All logs" (default) or create your own filter
+        description (string): Description
+        send_to_panorama (bool): Send to panorama
+        send_email (string): Send email profile
+        send_snmp (string): Send snmp profile
+        send_syslog (string): Send syslog profile
+        send_http (string): Send http profile
+
+    """
+
+    ROOT = Root.VSYS
+    SUFFIX = ENTRY
+
+    def _setup(self):
+        # xpaths
+        self._xpaths.add_profile(value="/log-settings/config/match-list")
+
+        # params
+        params = []
+
+        params.append(VersionedParamPath("filter", default="All Logs", path="filter"))
+
+        params.append(VersionedParamPath("description", path="description"))
+
+        params.append(
+            VersionedParamPath(
+                "send_to_panorama", vartype="yesno", path="send-to-panorama"
+            )
+        )
+
+        params.append(
+            VersionedParamPath("send_email", vartype="member", path="send-email")
+        )
+
+        params.append(
+            VersionedParamPath("send_snmp", vartype="member", path="send-snmptrap")
+        )
+
+        params.append(
+            VersionedParamPath("send_syslog", vartype="member", path="send-syslog")
+        )
+
+        params.append(
+            VersionedParamPath("send_http", vartype="member", path="send-http")
+        )
+
+        self._params = tuple(params)
+
+
 class PasswordProfile(VersionedPanObject):
     """Password profile object
 

--- a/panos/device.py
+++ b/panos/device.py
@@ -374,15 +374,17 @@ class SystemSettings(VersionedPanObject):
 class LogSettingsSystem(VersionedPanObject):
     """Firewall or Panorama device log settings system
 
+    Note: This is valid for PANS-OS 8.0+.
+
     Args:
         name (string): The name
         filter (string): Valid values are "All logs" (default) or create your own filter
         description (string): Description
         send_to_panorama (bool): Send to panorama
-        send_email (string): Send email profile
-        send_snmp (string): Send snmp profile
-        send_syslog (string): Send syslog profile
-        send_http (string): Send http profile
+        send_email (list): Send email profile
+        send_snmp (list): Send snmp profile
+        send_syslog (list): Send syslog profile
+        send_http (list): Send http profile
 
     """
 
@@ -428,15 +430,17 @@ class LogSettingsSystem(VersionedPanObject):
 class LogSettingsConfig(VersionedPanObject):
     """Firewall or Panorama device log settings configuration
 
+    Note: This is valid for PANS-OS 8.0+.
+
     Args:
         name (string): The name
         filter (string): Valid values are "All logs" (default) or create your own filter
         description (string): Description
         send_to_panorama (bool): Send to panorama
-        send_email (string): Send email profile
-        send_snmp (string): Send snmp profile
-        send_syslog (string): Send syslog profile
-        send_http (string): Send http profile
+        send_email (list): Send email profile
+        send_snmp (list): Send snmp profile
+        send_syslog (list): Send syslog profile
+        send_http (list): Send http profile
 
     """
 

--- a/panos/device.py
+++ b/panos/device.py
@@ -130,6 +130,7 @@ class Vsys(VersionedPanObject):
         "objects.LogForwardingProfile",
         "objects.DynamicUserGroup",
         "objects.Region",
+        "objects.Edl",
         "policies.Rulebase",
         "network.EthernetInterface",
         "network.AggregateInterface",

--- a/panos/firewall.py
+++ b/panos/firewall.py
@@ -62,6 +62,8 @@ class Firewall(PanDevice):
         "device.Vsys",
         "device.VsysResources",
         "device.SystemSettings",
+        "device.LogSettingsSystem",
+        "device.LogSettingsConfig",
         "device.PasswordProfile",
         "device.Administrator",
         "device.Telemetry",

--- a/panos/firewall.py
+++ b/panos/firewall.py
@@ -84,6 +84,7 @@ class Firewall(PanDevice):
         "objects.LogForwardingProfile",
         "objects.DynamicUserGroup",
         "objects.Region",
+        "objects.Edl",
         "policies.Rulebase",
         "network.EthernetInterface",
         "network.AggregateInterface",

--- a/panos/objects.py
+++ b/panos/objects.py
@@ -1081,3 +1081,164 @@ class Region(VersionedPanObject):
         )
 
         self._params = tuple(params)
+
+
+class Edl(VersionedPanObject):
+    """External Dynamic List.
+
+    Args:
+        name (str): The name.
+        edl_type (str): The EDL type.
+        description (str): Description.
+        source (str): Source.
+        exceptions (list): (PAN-OS 8.0+) Exceptions.
+        certificate_profile (str): (PAN-OS 8.0+) Profile for authenticating client certificates.
+        username (str): (PAN-OS 8.0+) Username auth.
+        password (str): (PAN-OS 8.0+) Password auth.
+        expand_domain (bool): (PAN-OS 9.0+) Enable/disable expand domain (requires
+            `edl_type=domain`).
+        repeat (str): Retrieval interval.  Valid values are "five-minute", "hourly",
+            "daily", "weekly", or "monthly".
+        repeat_at (str): The time specification for the given repeat value.
+        repeat_day_of_week (str): For `repeat=daily`, the day of the week.
+        repeat_day_of_month (int): For `repeat=monthly`, the day of the month.
+
+    """
+
+    ROOT = Root.VSYS
+    SUFFIX = ENTRY
+
+    def _setup(self):
+        # xpaths
+        self._xpaths.add_profile(value="/external-list")
+
+        # params
+        params = []
+
+        params.append(
+            VersionedParamPath(
+                "edl_type", default="ip", path="type", values=("ip", "domain", "url"),
+            ),
+        )
+        params[-1].add_profile(
+            "8.0.0",
+            path="type/{edl_type}",
+            values=("ip", "domain", "url", "predefined-ip"),
+        )
+        params[-1].add_profile(
+            "10.0.0",
+            path="type/{edl_type}",
+            values=("ip", "domain", "url", "predefined-ip", "predefined-url"),
+        )
+        params.append(VersionedParamPath("description", path="description",),)
+        params[-1].add_profile(
+            "8.0.0", path="type/{edl_type}/description",
+        )
+        params.append(VersionedParamPath("source", path="url",),)
+        params[-1].add_profile(
+            "8.0.0", path="type/{edl_type}/url",
+        )
+        params.append(VersionedParamPath("exceptions", exclude=True,),)
+        params[-1].add_profile(
+            "8.0.0", vartype="member", path="type/{edl_type}/exception-list",
+        )
+        params.append(VersionedParamPath("certificate_profile", exclude=True,))
+        params[-1].add_profile(
+            "8.0.0",
+            path="type/{edl_type}/certificate-profile",
+            condition={"edl_type": ["ip", "domain", "url"]},
+        )
+        params.append(VersionedParamPath("username", exclude=True,))
+        params[-1].add_profile(
+            "8.0.0",
+            path="type/{edl_type}/auth/username",
+            condition={"edl_type": ["ip", "domain", "url"]},
+        )
+        params.append(VersionedParamPath("password", exclude=True,))
+        params[-1].add_profile(
+            "8.0.0",
+            path="type/{edl_type}/auth/password",
+            vartype="encrypted",
+            condition={"edl_type": ["ip", "domain", "url"]},
+        )
+        params.append(VersionedParamPath("expand_domain", exclude=True,),)
+        params[-1].add_profile(
+            "9.0.0",
+            path="type/{edl_type}/expand-domain",
+            vartype="yesno",
+            condition={"edl_type": "domain"},
+        )
+        params.append(
+            VersionedParamPath(
+                "repeat",
+                path="recurring/{repeat}",
+                values=("five-minute", "hourly", "daily", "weekly", "monthly"),
+            ),
+        )
+        params[-1].add_profile(
+            "8.0.0",
+            path="type/{edl_type}/recurring/{repeat}",
+            values=("five-minute", "hourly", "daily", "weekly", "monthly"),
+            condition={"edl_type": ["ip", "domain", "url"]},
+        )
+        params.append(
+            VersionedParamPath(
+                "repeat_at",
+                path="recurring/{repeat}/at",
+                condition={"repeat": ["daily", "weekly", "monthly"]},
+            ),
+        )
+        params[-1].add_profile(
+            "8.0.0",
+            path="type/{edl_type}/recurring/{repeat}/at",
+            condition={
+                "edl_type": ["ip", "domain", "url"],
+                "repeat": ["daily", "weekly", "monthly"],
+            },
+        )
+        params.append(
+            VersionedParamPath(
+                "repeat_day_of_week",
+                path="recurring/{repeat}/day-of-week",
+                condition={"repeat": "weekly"},
+                values=(
+                    "sunday",
+                    "monday",
+                    "tuesday",
+                    "wednesday",
+                    "thursday",
+                    "friday",
+                    "saturday",
+                ),
+            ),
+        )
+        params[-1].add_profile(
+            "8.0.0",
+            path="type/{edl_type}/recurring/{repeat}/day-of-week",
+            values=(
+                "sunday",
+                "monday",
+                "tuesday",
+                "wednesday",
+                "thursday",
+                "friday",
+                "saturday",
+            ),
+            condition={"edl_type": ["ip", "domain", "url"], "repeat": "weekly",},
+        )
+        params.append(
+            VersionedParamPath(
+                "repeat_day_of_month",
+                vartype="int",
+                path="recurring/{repeat}/day-of-month",
+                condition={"repeat": "monthly"},
+            ),
+        )
+        params[-1].add_profile(
+            "8.0.0",
+            vartype="int",
+            path="type/{edl_type}/recurring/{repeat}/day-of-month",
+            condition={"edl_type": ["ip", "domain", "url"], "repeat": "monthly",},
+        )
+
+        self._params = tuple(params)

--- a/panos/panorama.py
+++ b/panos/panorama.py
@@ -66,6 +66,7 @@ class DeviceGroup(VersionedPanObject):
         "objects.CustomUrlCategory",
         "objects.LogForwardingProfile",
         "objects.Region",
+        "objects.Edl",
         "policies.PreRulebase",
         "policies.PostRulebase",
     )

--- a/panos/panorama.py
+++ b/panos/panorama.py
@@ -177,6 +177,8 @@ class Template(VersionedPanObject):
     CHILDTYPES = (
         "device.Vsys",
         "device.SystemSettings",
+        "device.LogSettingsSystem",
+        "device.LogSettingsConfig",
         "device.PasswordProfile",
         "device.Administrator",
         "ha.HighAvailability",
@@ -258,6 +260,8 @@ class TemplateStack(VersionedPanObject):
     CHILDTYPES = (
         "device.Vsys",
         "device.SystemSettings",
+        "device.LogSettingsSystem",
+        "device.LogSettingsConfig",
         "device.PasswordProfile",
         "device.Administrator",
         "ha.HighAvailability",


### PR DESCRIPTION
## Description

Add new functionality log settings on system and config.
This is done by adding two new class (LogSettingsSystem and LogSettingsConfig) in device.py.

## Motivation and Context

adds a new functionality.

## How Has This Been Tested?

This has been tested on panorama and physical firewall 5220 on version 9.0.10 with python 3.8
below result from panorama.
```
          templates tmpl-common-test;
+          config {
+            shared {
+              log-settings {
+                email {
+                  email_profil {
+                    server {
+                      1.1.1.1 {
+                        display-name myname;
+                        gateway 1.1.1.1;
+                        from myname@name.com;
+                        to tomyname@myname.com;
+                      }
+                    }
+                  }
+                }
+                system {
+                  match-list {
+                    logsystemsystettings_test {
+                      filter "All Logs";
+                      send-email email_profile;
+                      send-snmptrap snmp-profile;
+                      send-syslog srv-profile;
+                      send-http http_profile;
+                    }
+                  }
+                }

```

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ X ] I have updated the documentation accordingly.
- [ X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ X ] All new and existing tests passed.
