### PR TITLE
chore: Add warning when on EOL python

### DIFF
--- a/panos/__init__.py
+++ b/panos/__init__.py
@@ -36,11 +36,12 @@ from distutils.version import LooseVersion  # Used by PanOSVersion class
 # Warn if running on end-of-life python
 if sys.version_info < (3, 6):
     import warnings
+
     warnings.warn(
-        "pan-os-python - Running on end-of-life python version ({0}). "
-        "This python version is not supported and might cause problems. "
-        "Please upgrade to Python 3.6 or higher.".format(sys.version.split(' ')[0]),
-        RuntimeWarning
+        "pan-os-python - Running on end-of-life Python version ({0}). "
+        "This Python version is not supported and might cause problems. "
+        "Please upgrade to Python 3.6 or higher.".format(sys.version.split(" ")[0]),
+        RuntimeWarning,
     )
 
 try:

--- a/panos/__init__.py
+++ b/panos/__init__.py
@@ -30,7 +30,18 @@ __version__ = "1.2.0"
 
 
 import logging
+import sys
 from distutils.version import LooseVersion  # Used by PanOSVersion class
+
+# Warn if running on end-of-life python
+if sys.version_info < (3, 6):
+    import warnings
+    warnings.warn(
+        "pan-os-python - Running on end-of-life python version ({0}). "
+        "This python version is not supported and might cause problems. "
+        "Please upgrade to Python 3.6 or higher.".format(sys.version.split(' ')[0]),
+        RuntimeWarning
+    )
 
 try:
     import pan


### PR DESCRIPTION
Warning produced when running on end-of-life python version:

```
>>> import panos
panos/__init__.py:44: RuntimeWarning: pan-os-python - Running on end-of-life Python version (2.7.18). This Python version is not supported and might cause problems. Please upgrade to Python 3.6 or higher.
  RuntimeWarning,
```

closes #341