### PR TITLE
#347 - Adding protocol to EmailServer class

### DIFF
--- a/panos/device.py
+++ b/panos/device.py
@@ -1032,6 +1032,7 @@ class EmailServer(VersionedPanObject):
         to (str): To email address
         also_to (str): Additional destination email address
         email_gateway (str): IP address or FQDN of email gateway to use
+        protocol (str): SMTP for clear-text or TLS for encrypted
 
     """
 
@@ -1050,6 +1051,7 @@ class EmailServer(VersionedPanObject):
         params.append(VersionedParamPath("to", path="to"))
         params.append(VersionedParamPath("also_to", path="and-also-to"))
         params.append(VersionedParamPath("email_gateway", path="gateway"))
+        params.append(VersionedParamPath("protocol", path="protocol"))
 
         self._params = tuple(params)
 
@@ -1126,7 +1128,11 @@ class LdapServerProfile(VersionedPanObject):
             )
         )
         params.append(
-            VersionedParamPath("disabled", vartype="yesno", path="disabled",),
+            VersionedParamPath(
+                "disabled",
+                vartype="yesno",
+                path="disabled",
+            ),
         )
 
         self._params = tuple(params)
@@ -1272,7 +1278,10 @@ class SyslogServer(VersionedPanObject):
                 "facility",
                 default="LOG_USER",
                 path="facility",
-                values=["LOG_USER",] + ["LOG_LOCAL{0}".format(x) for x in range(8)],
+                values=[
+                    "LOG_USER",
+                ]
+                + ["LOG_LOCAL{0}".format(x) for x in range(8)],
             )
         )
 

--- a/panos/device.py
+++ b/panos/device.py
@@ -1051,7 +1051,11 @@ class EmailServer(VersionedPanObject):
         params.append(VersionedParamPath("to", path="to"))
         params.append(VersionedParamPath("also_to", path="and-also-to"))
         params.append(VersionedParamPath("email_gateway", path="gateway"))
-        params.append(VersionedParamPath("protocol", path="protocol"))
+        params.append(
+            VersionedParamPath(
+                "protocol", path="protocol", default="SMTP", values=["SMTP", "TLS"]
+            )
+        )
 
         self._params = tuple(params)
 
@@ -1128,11 +1132,7 @@ class LdapServerProfile(VersionedPanObject):
             )
         )
         params.append(
-            VersionedParamPath(
-                "disabled",
-                vartype="yesno",
-                path="disabled",
-            ),
+            VersionedParamPath("disabled", vartype="yesno", path="disabled",),
         )
 
         self._params = tuple(params)
@@ -1278,10 +1278,7 @@ class SyslogServer(VersionedPanObject):
                 "facility",
                 default="LOG_USER",
                 path="facility",
-                values=[
-                    "LOG_USER",
-                ]
-                + ["LOG_LOCAL{0}".format(x) for x in range(8)],
+                values=["LOG_USER",] + ["LOG_LOCAL{0}".format(x) for x in range(8)],
             )
         )
 

--- a/panos/device.py
+++ b/panos/device.py
@@ -1129,11 +1129,7 @@ class LdapServerProfile(VersionedPanObject):
             )
         )
         params.append(
-            VersionedParamPath(
-                "disabled",
-                vartype="yesno",
-                path="disabled",
-            ),
+            VersionedParamPath("disabled", vartype="yesno", path="disabled",),
         )
 
         self._params = tuple(params)
@@ -1279,10 +1275,7 @@ class SyslogServer(VersionedPanObject):
                 "facility",
                 default="LOG_USER",
                 path="facility",
-                values=[
-                    "LOG_USER",
-                ]
-                + ["LOG_LOCAL{0}".format(x) for x in range(8)],
+                values=["LOG_USER",] + ["LOG_LOCAL{0}".format(x) for x in range(8)],
             )
         )
 

--- a/panos/device.py
+++ b/panos/device.py
@@ -1051,11 +1051,8 @@ class EmailServer(VersionedPanObject):
         params.append(VersionedParamPath("to", path="to"))
         params.append(VersionedParamPath("also_to", path="and-also-to"))
         params.append(VersionedParamPath("email_gateway", path="gateway"))
-        params.append(
-            VersionedParamPath(
-                "protocol", path="protocol", default="SMTP", values=["SMTP", "TLS"]
-            )
-        )
+        params.append(VersionedParamPath("protocol", exclude=True, default="SMTP"))
+        params[-1].add_profile("10.0.0", path="protocol", values=["SMTP", "TLS"])
 
         self._params = tuple(params)
 
@@ -1132,7 +1129,11 @@ class LdapServerProfile(VersionedPanObject):
             )
         )
         params.append(
-            VersionedParamPath("disabled", vartype="yesno", path="disabled",),
+            VersionedParamPath(
+                "disabled",
+                vartype="yesno",
+                path="disabled",
+            ),
         )
 
         self._params = tuple(params)
@@ -1278,7 +1279,10 @@ class SyslogServer(VersionedPanObject):
                 "facility",
                 default="LOG_USER",
                 path="facility",
-                values=["LOG_USER",] + ["LOG_LOCAL{0}".format(x) for x in range(8)],
+                values=[
+                    "LOG_USER",
+                ]
+                + ["LOG_LOCAL{0}".format(x) for x in range(8)],
             )
         )
 


### PR DESCRIPTION
Signed-off-by: Stephen Steiner <ssteiner@paloaltonetworks.com>

## Description

Adding `protocol` attribute to the `EmailServer` class in `panos.device` to support the changes in PanOS 10+

## Motivation and Context

Since the introduction of PanOS 10, the email server configuration requires the protocol attribute as either SMTP or TLS

## How Has This Been Tested?

Ran `poetry run make test`
Ran `poetry run make test-all` (Failed, but for other than changes made)

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
