### PR TITLE
fix: Remove legacy HA interface stubs

### DIFF
--- a/panos/ha.py
+++ b/panos/ha.py
@@ -559,10 +559,5 @@ class HighAvailability(VersionedPanObject):
 
         # stubs
         self._stubs.add_profile(
-            "0.0.0",
-            "interface/ha1",
-            "interface/ha1-backup",
-            "interface/ha2",
-            "interface/ha2-backup",
-            "interface/ha3",
+            "0.0.0", "interface/ha1",
         )

--- a/panos/ha.py
+++ b/panos/ha.py
@@ -39,6 +39,7 @@ class HighAvailabilityInterface(PanObject):
 
     """
 
+    NAME = None
     HA_SYNC = False
 
     # TODO: Support encryption

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -15,6 +15,7 @@ try:
     from unittest import mock
 except ImportError:
     import mock
+
 import unittest
 import xml.etree.ElementTree as ET
 
@@ -169,11 +170,11 @@ class TestElementStr_7_0(unittest.TestCase):
                 b"<netmask>255.255.255.0</netmask><port>ethernet1/6</port>",
                 b"<gateway>10.5.1.2</gateway><link-speed>1000</link-speed>",
                 b"<link-duplex>auto</link-duplex><monitor-hold-time>7",
-                b"</monitor-hold-time></ha1><ha1-backup /><ha2>",
+                b"</monitor-hold-time></ha1><ha2>",
                 b"<ip-address>10.6.1.1</ip-address><netmask>255.255.255.0",
                 b"</netmask><port>ethernet1/7</port><gateway>10.6.1.2</gateway>",
                 b"<link-speed>1000</link-speed><link-duplex>auto</link-duplex>",
-                b"</ha2><ha2-backup /><ha3 /></interface></high-availability>",
+                b"</ha2></interface></high-availability>",
             ]
         )
 


### PR DESCRIPTION
## Description

> Note: Merge with "Rebase and Merge", not squash.

Removes some HA interface stubs and assigns no 'name' to the HA interface class. This fixes 2 issues:

Issue 1: HA interfaces created with args, instead of kwargs, were not getting the correct IP address because pan-os-python expected the first arg to be a name.

Issue 2: #350 - HA interface stubs were created in the HighAvailability instance, but some newer models of VM-Series do not have these interfaces (eg. ha1-backup), so the stub caused an error.

## How Has This Been Tested?

Tested on VM-Series that supports ha1-backup and VM-Series that does not support ha1-backup. Works on both.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
