### PR TITLE
implemented a timeout option into userid register()

### DIFF
--- a/panos/userid.py
+++ b/panos/userid.py
@@ -223,7 +223,7 @@ class UserId(object):
             ET.SubElement(logout, "entry", {"name": user[0], "ip": user[1]})
         self.send(root)
 
-    def register(self, ip, tags):
+    def register(self, ip, tags, timeout=None):
         """Register an ip tag for a Dynamic Address Group
 
         This method can be batched with batch_start() and batch_end().
@@ -231,8 +231,12 @@ class UserId(object):
         Args:
             ip (:obj:`list` or :obj:`str`): IP address(es) to tag
             tags (:obj:`list` or :obj:`str`): The tag(s) for the IP address
+            timeout (int): (Optional) The timeout for the given tags.
 
         """
+        if timeout is not None:
+            timeout = int(timeout)
+
         root, payload = self._create_uidmessage()
         register = payload.find("register")
         if register is None:
@@ -247,8 +251,12 @@ class UserId(object):
             if tagelement is None:
                 entry = ET.SubElement(register, "entry", {"ip": c_ip})
                 tagelement = ET.SubElement(entry, "tag")
+            # Now add in the tags with the specified timeout.
+            props = {}
+            if timeout is not None:
+            	props["timeout"] = "{0}".format(timeout)
             for tag in tags:
-                member = ET.SubElement(tagelement, "member")
+                member = ET.SubElement(tagelement, "member", props)
                 member.text = tag
         self.send(root)
 


### PR DESCRIPTION
## Description

I've added a timeout option for registering an ip address (`userid: register()`)

## Motivation and Context

I was able to tag an user with a timeout, but this "timeout"-option isn't available for registering an ip address to a dynamic access group.
So I implemented the missing timeout option to the `userid: register()` function.


## How Has This Been Tested?

I can now successfully register an ip address with a timeout (IP-Tag).

## Screenshots (if appropriate)

![2021-08-24 21_50_10-Window](https://user-images.githubusercontent.com/15085166/130681090-3dfdd1b8-83f8-4663-913e-6fa8869eda4e.png)

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
