### PR TITLE
add optional timeout for userid register()

### DIFF
--- a/panos/userid.py
+++ b/panos/userid.py
@@ -718,7 +718,13 @@ class UserId(object):
                 te = entry.find("./tag")
                 break
         else:
-            entry = ET.SubElement(ru, "entry", {"user": user,})
+            entry = ET.SubElement(
+                ru,
+                "entry",
+                {
+                    "user": user,
+                },
+            )
             te = ET.SubElement(entry, "tag")
 
         # Now add in the tags with the specified timeout.
@@ -761,7 +767,13 @@ class UserId(object):
             if entry.attrib["user"] == user:
                 break
         else:
-            entry = ET.SubElement(uu, "entry", {"user": user,})
+            entry = ET.SubElement(
+                uu,
+                "entry",
+                {
+                    "user": user,
+                },
+            )
 
         # Do tag removal.
         te = entry.find("./tag")

--- a/panos/userid.py
+++ b/panos/userid.py
@@ -248,7 +248,9 @@ class UserId(object):
             if tagelement is None:
                 entry = ET.SubElement(register, "entry", {"ip": c_ip})
                 if timeout:
-                    entry.set("timeout", str(timeout))
+                    if timeout == "0":
+                        timeout = None
+                    entry.set("timeout", timeout)
                 tagelement = ET.SubElement(entry, "tag")
             for tag in tags:
                 member = ET.SubElement(tagelement, "member")

--- a/panos/userid.py
+++ b/panos/userid.py
@@ -223,7 +223,7 @@ class UserId(object):
             ET.SubElement(logout, "entry", {"name": user[0], "ip": user[1]})
         self.send(root)
 
-    def register(self, ip, tags, timeout=60):
+    def register(self, ip, tags, timeout=None):
         """Register an ip tag for a Dynamic Address Group
 
         This method can be batched with batch_start() and batch_end().
@@ -248,7 +248,7 @@ class UserId(object):
             if tagelement is None:
                 entry = ET.SubElement(register, "entry", {"ip": c_ip})
                 if timeout:
-                    entry.set("timeout", int(timeout))
+                    entry.set("timeout", str(timeout))
                 tagelement = ET.SubElement(entry, "tag")
             for tag in tags:
                 member = ET.SubElement(tagelement, "member")
@@ -417,7 +417,7 @@ class UserId(object):
             self.unregister(ip, tags)
         self.batch_end()
 
-    def audit_registered_ip_for_tag(self, tag, ip_addresses, timeout=60):
+    def audit_registered_ip_for_tag(self, tag, ip_addresses, timeout=None):
         """Synchronize the current registered-ip tag to tag only the specificied IP addresses.
 
         Sets the registered-ip list for a single tag on the device. Regardless
@@ -453,7 +453,7 @@ class UserId(object):
                 self.register(ip, tag, timeout)
         self.batch_end()
 
-    def audit_registered_ip(self, ip_tags_pairs, timeout=60):
+    def audit_registered_ip(self, ip_tags_pairs, timeout=None):
         """Synchronize the current registered-ip tag list to this exact set of ip-tags
 
         Sets the registered-ip tag list on the device.

--- a/panos/userid.py
+++ b/panos/userid.py
@@ -436,7 +436,7 @@ class UserId(object):
         Args:
             tag (string): Tag to audit
             ip_addresses(list): List of IP addresses that should have the tag
-            timeout (string): The optional timeout value in minutes.
+            timeout (string): The optional timeout value in seconds.
 
         """
         device_list = self.get_registered_ip(tags=tag, prefix=self.prefix)
@@ -470,7 +470,7 @@ class UserId(object):
 
         Args:
             ip_tags_pairs (dict): dictionary where keys are ip addresses and values or tuples of tags
-            timeout (string): The optional timeout value in minutes.
+            timeout (string): The optional timeout value in seconds.
 
         """
         device_list = self.get_registered_ip()

--- a/panos/userid.py
+++ b/panos/userid.py
@@ -250,9 +250,8 @@ class UserId(object):
                 tagelement = ET.SubElement(entry, "tag")
             for tag in tags:
                 member = ET.SubElement(tagelement, "member")
-                if timeout is None:
-                    timeout = "0"
-                member.set("timeout", str(timeout))
+                if timeout is not None:
+                    member.set("timeout", str(timeout))
                 member.text = tag
         self.send(root)
 

--- a/panos/userid.py
+++ b/panos/userid.py
@@ -231,7 +231,7 @@ class UserId(object):
         Args:
             ip (:obj:`list` or :obj:`str`): IP address(es) to tag
             tags (:obj:`list` or :obj:`str`): The tag(s) for the IP address
-            timeout (:obj:`str`): The optional timeout value in seconds. (Max is 2,592,000 sec (30 days))
+            timeout (string): The optional timeout value in seconds. (Max is 2,592,000 sec (30 days))
 
         """
         root, payload = self._create_uidmessage()

--- a/panos/userid.py
+++ b/panos/userid.py
@@ -436,7 +436,7 @@ class UserId(object):
         Args:
             tag (string): Tag to audit
             ip_addresses(list): List of IP addresses that should have the tag
-            timeout (:obj:`str`): The optional timeout value in minutes.
+            timeout (string): The optional timeout value in minutes.
 
         """
         device_list = self.get_registered_ip(tags=tag, prefix=self.prefix)
@@ -470,7 +470,7 @@ class UserId(object):
 
         Args:
             ip_tags_pairs (dict): dictionary where keys are ip addresses and values or tuples of tags
-            timeout (:obj:`str`): The optional timeout value in minutes.
+            timeout (string): The optional timeout value in minutes.
 
         """
         device_list = self.get_registered_ip()

--- a/panos/userid.py
+++ b/panos/userid.py
@@ -223,7 +223,7 @@ class UserId(object):
             ET.SubElement(logout, "entry", {"name": user[0], "ip": user[1]})
         self.send(root)
 
-    def register(self, ip, tags):
+    def register(self, ip, tags, timeout=None):
         """Register an ip tag for a Dynamic Address Group
 
         This method can be batched with batch_start() and batch_end().
@@ -231,6 +231,7 @@ class UserId(object):
         Args:
             ip (:obj:`list` or :obj:`str`): IP address(es) to tag
             tags (:obj:`list` or :obj:`str`): The tag(s) for the IP address
+            timeout (:obj:`str`): The optional timeout value in minutes
 
         """
         root, payload = self._create_uidmessage()
@@ -246,6 +247,8 @@ class UserId(object):
             tagelement = register.find("./entry[@ip='%s']/tag" % c_ip)
             if tagelement is None:
                 entry = ET.SubElement(register, "entry", {"ip": c_ip})
+                if timeout:
+                    entry.set("timeout", str(timeout))
                 tagelement = ET.SubElement(entry, "tag")
             for tag in tags:
                 member = ET.SubElement(tagelement, "member")
@@ -414,7 +417,7 @@ class UserId(object):
             self.unregister(ip, tags)
         self.batch_end()
 
-    def audit_registered_ip_for_tag(self, tag, ip_addresses):
+    def audit_registered_ip_for_tag(self, tag, ip_addresses, timeout=None):
         """Synchronize the current registered-ip tag to tag only the specificied IP addresses.
 
         Sets the registered-ip list for a single tag on the device. Regardless
@@ -433,6 +436,7 @@ class UserId(object):
         Args:
             tag (string): Tag to audit
             ip_addresses(list): List of IP addresses that should have the tag
+            timeout (:obj:`str`): The optional timeout value in minutes.
 
         """
         device_list = self.get_registered_ip(tags=tag, prefix=self.prefix)
@@ -446,10 +450,10 @@ class UserId(object):
         for ip in ip_addresses:
             if ip not in registered_ips:
                 # The IP is requested, register it with this tag
-                self.register(ip, tag)
+                self.register(ip, tag, timeout)
         self.batch_end()
 
-    def audit_registered_ip(self, ip_tags_pairs):
+    def audit_registered_ip(self, ip_tags_pairs, timeout=None):
         """Synchronize the current registered-ip tag list to this exact set of ip-tags
 
         Sets the registered-ip tag list on the device.
@@ -466,6 +470,7 @@ class UserId(object):
 
         Args:
             ip_tags_pairs (dict): dictionary where keys are ip addresses and values or tuples of tags
+            timeout (:obj:`str`): The optional timeout value in minutes.
 
         """
         device_list = self.get_registered_ip()
@@ -491,7 +496,7 @@ class UserId(object):
         requested_list = {ip: tags for ip, tags in requested_list.items() if tags}
         # Handle registrations
         for ip, tags in requested_list.items():
-            self.register(ip, tags)
+            self.register(ip, tags, timeout)
         self.batch_end()
 
     def set_group(self, group, users):
@@ -555,7 +560,7 @@ class UserId(object):
             return
 
         """
-        Example returned XML:
+        example returned XML:
 
         9.1:
         <response status="success"><result><![CDATA[\nmalicious_users \ncn=contractors,cn=users,dc=nam,dc=local \ntemp_contractors_dynamic_group \nspecial_project \nrisky_users \ncn=employees,cn=users,dc=nam,dc=local \nhigh_risk_users \n\nTotal: 7\n* : Custom Group\n\n]]></result></response>

--- a/panos/userid.py
+++ b/panos/userid.py
@@ -231,7 +231,7 @@ class UserId(object):
         Args:
             ip (:obj:`list` or :obj:`str`): IP address(es) to tag
             tags (:obj:`list` or :obj:`str`): The tag(s) for the IP address
-            timeout (:obj:`str`): The optional timeout value in seconds.
+            timeout (:obj:`str`): The optional timeout value in seconds. (Max is 2,592,000 sec (30 days))
 
         """
         root, payload = self._create_uidmessage()

--- a/panos/userid.py
+++ b/panos/userid.py
@@ -247,13 +247,12 @@ class UserId(object):
             tagelement = register.find("./entry[@ip='%s']/tag" % c_ip)
             if tagelement is None:
                 entry = ET.SubElement(register, "entry", {"ip": c_ip})
-                if timeout is not None:
-                    entry.set("timeout", int(timeout))
                 tagelement = ET.SubElement(entry, "tag")
             for tag in tags:
                 member = ET.SubElement(tagelement, "member")
-                if timeout:
-                    member.set("timeout", str(timeout))
+                if timeout is None:
+                    timeout = "0"
+                member.set("timeout", str(timeout))
                 member.text = tag
         self.send(root)
 

--- a/panos/userid.py
+++ b/panos/userid.py
@@ -248,7 +248,7 @@ class UserId(object):
             if tagelement is None:
                 entry = ET.SubElement(register, "entry", {"ip": c_ip})
                 if timeout:
-                    entry.set("timeout", str(timeout))
+                    entry.set("timeout", int(timeout))
                 tagelement = ET.SubElement(entry, "tag")
             for tag in tags:
                 member = ET.SubElement(tagelement, "member")

--- a/panos/userid.py
+++ b/panos/userid.py
@@ -224,14 +224,14 @@ class UserId(object):
         self.send(root)
 
     def register(self, ip, tags, timeout=None):
-        """Register an ip tag for a Dynamic Address Group
+        """Register an ip tag for a Dynamic Address Group.
 
         This method can be batched with batch_start() and batch_end().
 
         Args:
             ip (:obj:`list` or :obj:`str`): IP address(es) to tag
             tags (:obj:`list` or :obj:`str`): The tag(s) for the IP address
-            timeout (:obj:`str`): The optional timeout value in minutes
+            timeout (:obj:`str`): The optional timeout value in seconds.
 
         """
         root, payload = self._create_uidmessage()

--- a/panos/userid.py
+++ b/panos/userid.py
@@ -223,7 +223,7 @@ class UserId(object):
             ET.SubElement(logout, "entry", {"name": user[0], "ip": user[1]})
         self.send(root)
 
-    def register(self, ip, tags, timeout=None):
+    def register(self, ip, tags, timeout=60):
         """Register an ip tag for a Dynamic Address Group
 
         This method can be batched with batch_start() and batch_end().
@@ -417,7 +417,7 @@ class UserId(object):
             self.unregister(ip, tags)
         self.batch_end()
 
-    def audit_registered_ip_for_tag(self, tag, ip_addresses, timeout=None):
+    def audit_registered_ip_for_tag(self, tag, ip_addresses, timeout=60):
         """Synchronize the current registered-ip tag to tag only the specificied IP addresses.
 
         Sets the registered-ip list for a single tag on the device. Regardless
@@ -453,7 +453,7 @@ class UserId(object):
                 self.register(ip, tag, timeout)
         self.batch_end()
 
-    def audit_registered_ip(self, ip_tags_pairs, timeout=None):
+    def audit_registered_ip(self, ip_tags_pairs, timeout=60):
         """Synchronize the current registered-ip tag list to this exact set of ip-tags
 
         Sets the registered-ip tag list on the device.

--- a/tests/test_userid.py
+++ b/tests/test_userid.py
@@ -106,7 +106,7 @@ class TestUserId(unittest.TestCase):
         )
         fw.xapi
         fw.userid.batch_start()
-        fw.userid.register("172.16.172.16", "example-tag", timeout=60)
+        fw.userid.register("172.16.172.16", "example-tag", 15)
         fw.userid.register(
             ["172.16.172.172", "172.16.16.172"],
             [
@@ -121,7 +121,7 @@ class TestUserId(unittest.TestCase):
         )
         fw.xapi
         fw.userid.batch_start()
-        fw.userid.audit_registered_ip_for_tag("172.16.172.16", "example-tag", timeout=60)
+        fw.userid.audit_registered_ip_for_tag("172.16.172.16", "example-tag", 15)
         fw.userid.audit_registered_ip_for_tag(
             ["172.16.172.172", "172.16.16.172"],
             [
@@ -136,7 +136,7 @@ class TestUserId(unittest.TestCase):
         )
         fw.xapi
         fw.userid.batch_start()
-        fw.userid.audit_registered_ip("172.16.172.16", "example-tag", timeout=60)
+        fw.userid.audit_registered_ip("172.16.172.16", "example-tag", 15)
         fw.userid.audit_registered_ip(
             ["172.16.172.172", "172.16.16.172"],
             [

--- a/tests/test_userid.py
+++ b/tests/test_userid.py
@@ -100,53 +100,6 @@ class TestUserId(unittest.TestCase):
             ],
         )
 
-    """
-    def test_register(self):
-        fw = panos.firewall.Firewall(
-            "fw1", "user", "passwd", "authkey", serial="Serial", vsys="vsys2"
-        )
-        fw.xapi
-        fw.userid.batch_start()
-        fw.userid.register("172.16.172.16", "example-tag", "15")
-        fw.userid.register(
-            ["172.16.172.172", "172.16.16.172"],
-            [
-                "user2",
-                "tag1",
-            ],
-        )
-
-    def test_audit_registered_ip_for_tag(self):
-        fw = panos.firewall.Firewall(
-            "fw1", "user", "passwd", "authkey", serial="Serial", vsys="vsys2"
-        )
-        fw.xapi
-        fw.userid.batch_start()
-        fw.userid.audit_registered_ip_for_tag("172.16.172.16", "example-tag", "15")
-        fw.userid.audit_registered_ip_for_tag(
-            ["172.16.172.172", "172.16.16.172"],
-            [
-                "user2",
-                "tag1",
-            ],
-        )
-
-    def test_audit_registered_ip(self):
-        fw = panos.firewall.Firewall(
-            "fw1", "user", "passwd", "authkey", serial="Serial", vsys="vsys2"
-        )
-        fw.xapi
-        fw.userid.batch_start()
-        fw.userid.audit_registered_ip("172.16.172.16", "example-tag", "15")
-        fw.userid.audit_registered_ip(
-            ["172.16.172.172", "172.16.16.172"],
-            [
-                "user2",
-                "tag1",
-            ],
-        )
-    """
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_userid.py
+++ b/tests/test_userid.py
@@ -100,13 +100,14 @@ class TestUserId(unittest.TestCase):
             ],
         )
 
+    """
     def test_register(self):
         fw = panos.firewall.Firewall(
             "fw1", "user", "passwd", "authkey", serial="Serial", vsys="vsys2"
         )
         fw.xapi
         fw.userid.batch_start()
-        fw.userid.register("172.16.172.16", "example-tag", 15)
+        fw.userid.register("172.16.172.16", "example-tag", "15")
         fw.userid.register(
             ["172.16.172.172", "172.16.16.172"],
             [
@@ -121,7 +122,7 @@ class TestUserId(unittest.TestCase):
         )
         fw.xapi
         fw.userid.batch_start()
-        fw.userid.audit_registered_ip_for_tag("172.16.172.16", "example-tag", 15)
+        fw.userid.audit_registered_ip_for_tag("172.16.172.16", "example-tag", "15")
         fw.userid.audit_registered_ip_for_tag(
             ["172.16.172.172", "172.16.16.172"],
             [
@@ -136,7 +137,7 @@ class TestUserId(unittest.TestCase):
         )
         fw.xapi
         fw.userid.batch_start()
-        fw.userid.audit_registered_ip("172.16.172.16", "example-tag", 15)
+        fw.userid.audit_registered_ip("172.16.172.16", "example-tag", "15")
         fw.userid.audit_registered_ip(
             ["172.16.172.172", "172.16.16.172"],
             [
@@ -144,6 +145,7 @@ class TestUserId(unittest.TestCase):
                 "tag1",
             ],
         )
+    """
 
 
 if __name__ == "__main__":

--- a/tests/test_userid.py
+++ b/tests/test_userid.py
@@ -15,6 +15,7 @@ try:
     from unittest import mock
 except ImportError:
     import mock
+
 import sys
 import unittest
 
@@ -67,8 +68,18 @@ class TestUserId(unittest.TestCase):
         )
         fw.xapi
         fw.userid.batch_start()
-        fw.userid.tag_user("user1", ["tag1",])
-        fw.userid.tag_user("user2", ["tag1",])
+        fw.userid.tag_user(
+            "user1",
+            [
+                "tag1",
+            ],
+        )
+        fw.userid.tag_user(
+            "user2",
+            [
+                "tag1",
+            ],
+        )
 
     def test_batch_untag_user(self):
         fw = panos.firewall.Firewall(
@@ -76,8 +87,63 @@ class TestUserId(unittest.TestCase):
         )
         fw.xapi
         fw.userid.batch_start()
-        fw.userid.untag_user("user1", ["tag1",])
-        fw.userid.untag_user("user2", ["tag1",])
+        fw.userid.untag_user(
+            "user1",
+            [
+                "tag1",
+            ],
+        )
+        fw.userid.untag_user(
+            "user2",
+            [
+                "tag1",
+            ],
+        )
+
+    def test_register(self):
+        fw = panos.firewall.Firewall(
+            "fw1", "user", "passwd", "authkey", serial="Serial", vsys="vsys2"
+        )
+        fw.xapi
+        fw.userid.batch_start()
+        fw.userid.register("172.16.172.16", "example-tag", 60)
+        fw.userid.register(
+            ["172.16.172.172", "172.16.16.172"],
+            [
+                "user2",
+                "tag1",
+            ],
+        )
+
+    def test_audit_registered_ip_for_tag(self):
+        fw = panos.firewall.Firewall(
+            "fw1", "user", "passwd", "authkey", serial="Serial", vsys="vsys2"
+        )
+        fw.xapi
+        fw.userid.batch_start()
+        fw.userid.audit_registered_ip_for_tag("172.16.172.16", "example-tag", 60)
+        fw.userid.audit_registered_ip_for_tag(
+            ["172.16.172.172", "172.16.16.172"],
+            [
+                "user2",
+                "tag1",
+            ],
+        )
+
+    def test_audit_registered_ip(self):
+        fw = panos.firewall.Firewall(
+            "fw1", "user", "passwd", "authkey", serial="Serial", vsys="vsys2"
+        )
+        fw.xapi
+        fw.userid.batch_start()
+        fw.userid.audit_registered_ip("172.16.172.16", "example-tag", 60)
+        fw.userid.audit_registered_ip(
+            ["172.16.172.172", "172.16.16.172"],
+            [
+                "user2",
+                "tag1",
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_userid.py
+++ b/tests/test_userid.py
@@ -106,7 +106,7 @@ class TestUserId(unittest.TestCase):
         )
         fw.xapi
         fw.userid.batch_start()
-        fw.userid.register("172.16.172.16", "example-tag", 60)
+        fw.userid.register("172.16.172.16", "example-tag", timeout=60)
         fw.userid.register(
             ["172.16.172.172", "172.16.16.172"],
             [
@@ -121,7 +121,7 @@ class TestUserId(unittest.TestCase):
         )
         fw.xapi
         fw.userid.batch_start()
-        fw.userid.audit_registered_ip_for_tag("172.16.172.16", "example-tag", 60)
+        fw.userid.audit_registered_ip_for_tag("172.16.172.16", "example-tag", timeout=60)
         fw.userid.audit_registered_ip_for_tag(
             ["172.16.172.172", "172.16.16.172"],
             [
@@ -136,7 +136,7 @@ class TestUserId(unittest.TestCase):
         )
         fw.xapi
         fw.userid.batch_start()
-        fw.userid.audit_registered_ip("172.16.172.16", "example-tag", 60)
+        fw.userid.audit_registered_ip("172.16.172.16", "example-tag", timeout=60)
         fw.userid.audit_registered_ip(
             ["172.16.172.172", "172.16.16.172"],
             [


### PR DESCRIPTION
## Description

Ben Parker  2:39 PM

So this call should actaully support another argument [https://pan-os-python.readthedocs.io/en/latest/module-userid.html#panos.userid.UserId.audit_registered_ip](https://pan-os-python.readthedocs.io/en/latest/module-userid.html#panos.userid.UserId.audit_registered_ip])

the timeout like argument like [https://pan-os-python.readthedocs.io/en/latest/module-userid.html#panos.userid.UserId.audit_registered_ip](https://pan-os-python.readthedocs.io/en/latest/module-userid.html#panos.userid.UserId.audit_registered_ip)

Ben Parker  2:40 PM
Here is what the whole API call looks like 

```
https://{{host}}/api?key={{key}}&type=user-id&cmd=<uid-message><version>2.0</version><type>update</type><payload><register><entry ip="{{tagged-ip}}"><tag><member timeout="60">{{tag}}</member></tag></entry></register></payload></uid-message>
```

## Motivation and Context

Need update to XML API call

## How Has This Been Tested?

New unit test cases included

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
