### PR TITLE
bug: DecryptionRule wrong xpath.

### DIFF
--- a/panos/policies.py
+++ b/panos/policies.py
@@ -834,6 +834,10 @@ class DecryptionRule(VersionedPanObject):
             handshakes.
         log_failed_tls_handshakes (bool): (PAN-OS 10.0+) Log failed TLS handshakes.
         log_setting (str): (PAN-OS 10.0+) Log setting.
+        negate_target (bool): Target all but the listed target firewalls
+            (applies to panorama/device groups only)
+        target (list): Apply this policy to the listed firewalls only
+            (applies to panorama/device groups only)
 
     """
 
@@ -848,6 +852,12 @@ class DecryptionRule(VersionedPanObject):
         # params
         params = []
 
+        params.append(
+            VersionedParamPath("negate_target", path="target/negate", vartype="yesno")
+        )
+        params.append(
+            VersionedParamPath("target", path="target/devices", vartype="entry")
+        )
         params.append(VersionedParamPath("description", path="description"))
         params.append(VersionedParamPath("uuid", exclude=True))
         params[-1].add_profile("9.0.0", vartype="attrib", path="uuid")

--- a/panos/policies.py
+++ b/panos/policies.py
@@ -843,7 +843,7 @@ class DecryptionRule(VersionedPanObject):
 
     def _setup(self):
         # xpaths
-        self._xpaths.add_profile(value="/pbf/rules")
+        self._xpaths.add_profile(value="/decryption/rules")
 
         # params
         params = []

--- a/panos/policies.py
+++ b/panos/policies.py
@@ -838,6 +838,7 @@ class DecryptionRule(VersionedPanObject):
             (applies to panorama/device groups only)
         target (list): Apply this policy to the listed firewalls only
             (applies to panorama/device groups only)
+
     """
 
     SUFFIX = ENTRY

--- a/panos/policies.py
+++ b/panos/policies.py
@@ -838,7 +838,6 @@ class DecryptionRule(VersionedPanObject):
             (applies to panorama/device groups only)
         target (list): Apply this policy to the listed firewalls only
             (applies to panorama/device groups only)
-
     """
 
     SUFFIX = ENTRY
@@ -852,12 +851,6 @@ class DecryptionRule(VersionedPanObject):
         # params
         params = []
 
-        params.append(
-            VersionedParamPath("negate_target", path="target/negate", vartype="yesno")
-        )
-        params.append(
-            VersionedParamPath("target", path="target/devices", vartype="entry")
-        )
         params.append(VersionedParamPath("description", path="description"))
         params.append(VersionedParamPath("uuid", exclude=True))
         params[-1].add_profile("9.0.0", vartype="attrib", path="uuid")
@@ -949,6 +942,12 @@ class DecryptionRule(VersionedPanObject):
         params.append(VersionedParamPath("log_setting", exclude=True,))
         params[-1].add_profile(
             "10.0.0", path="log-setting",
+        )
+        params.append(
+            VersionedParamPath("negate_target", path="target/negate", vartype="yesno")
+        )
+        params.append(
+            VersionedParamPath("target", path="target/devices", vartype="entry")
         )
 
         self._params = tuple(params)


### PR DESCRIPTION
## Description

DecryptionRule _setup method was referencing wrong xpath for decryption rules.

## Motivation and Context

It fixes correctly parsing DecryptionRule objects.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
