### PR TITLE
feat: Make opstate more discoverable for users

### DIFF
--- a/panos/base.py
+++ b/panos/base.py
@@ -71,6 +71,7 @@ class PanObject(object):
     HA_SYNC = True
     TEMPLATE_NATIVE = False
     _UNKNOWN_PANOS_VERSION = (sys.maxsize, 0, 0)
+    OPSTATES = {}
 
     def __init__(self, *args, **kwargs):
         # Set the 'name' variable
@@ -129,6 +130,9 @@ class PanObject(object):
                 f = getattr(self, func)
                 if callable(f):
                     f()
+
+    def _setup_opstate(self):
+        self.opstate = OpStateContainer(self, self.OPSTATES)
 
     def __str__(self):
         return self.uid
@@ -3511,6 +3515,60 @@ class VsysOperations(VersionedPanObject):
             parent.extend(instances)
 
         return instances
+
+
+class OpStateContainer(object):
+    """Container for all opstate namespaces.
+
+    The name "opstate" is short for "operational state" and acts as a container
+    for non-configuration functionality to exist.
+
+    """
+
+    def __init__(self, obj, config):
+        for namespace, cls in config.items():
+            setattr(self, namespace, cls(obj))
+
+    def about(self):
+        """Returns information about this object's opstate namespaces.
+
+        Returns:
+            dict: Keys are the opstate's namespace, values are the classes.
+
+        """
+        return vars(self)
+
+
+class OpState(object):
+    """Parent class for all opstate namespaces."""
+
+    def __init__(self, obj, *args, **kwargs):
+        self.obj = obj
+        self._setup(*args, **kwargs)
+
+    def _setup(self, *args, **kwargs):
+        """Called during __init__."""
+        pass
+
+    def _str(self, elm, field):
+        if elm is not None:
+            val = elm.find("./{0}".format(field))
+            if val is not None:
+                return val.text
+
+    def _int(self, elm, field):
+        val = self._str(elm, field)
+        if val is not None:
+            return int(val)
+
+    def _datetime(self, elm, field, fmt):
+        val = self._str(elm, field)
+        if val is not None:
+            try:
+                return datetime.datetime.strptime(val, fmt)
+            except ValueError:
+                pass
+            return val
 
 
 class PanDevice(PanObject):

--- a/panos/panorama.py
+++ b/panos/panorama.py
@@ -26,87 +26,14 @@ import pan.commit
 import panos
 import panos.errors as err
 from panos import base, firewall, getlogger, policies, yesno
-from panos.base import ENTRY, MEMBER, PanObject, Root
+from panos.base import ENTRY, MEMBER, OpState, PanObject, Root
 from panos.base import VarPath as Var
 from panos.base import VersionedPanObject, VersionedParamPath
 
 logger = getlogger(__name__)
 
 
-class DeviceGroup(VersionedPanObject):
-    """Panorama Device-group
-
-    This class and the :class:`panos.panorama.Panorama` classes are the only objects that can
-    have a :class:`panos.firewall.Firewall` child object. In addition to a Firewall, a
-    DeviceGroup can have the same children objects as a :class:`panos.firewall.Firewall`
-    or :class:`panos.device.Vsys`.
-
-    See also :ref:`classtree`
-
-    Args:
-        name (str): Name of the device-group
-        tag (list): Tags as strings
-
-    """
-
-    ROOT = Root.DEVICE
-    SUFFIX = ENTRY
-    VSYS_LABEL = "device-group"
-    CHILDTYPES = (
-        "firewall.Firewall",
-        "objects.AddressObject",
-        "objects.AddressGroup",
-        "objects.ServiceObject",
-        "objects.ServiceGroup",
-        "objects.ApplicationObject",
-        "objects.ApplicationGroup",
-        "objects.ApplicationFilter",
-        "objects.ScheduleObject",
-        "objects.SecurityProfileGroup",
-        "objects.CustomUrlCategory",
-        "objects.LogForwardingProfile",
-        "objects.Region",
-        "objects.Edl",
-        "policies.PreRulebase",
-        "policies.PostRulebase",
-    )
-
-    def _setup(self):
-        # xpaths
-        self._xpaths.add_profile(value="/device-group")
-
-        # params
-        params = []
-
-        params.append(VersionedParamPath("tag", vartype="entry"))
-
-        self._params = tuple(params)
-
-    def _setup_opstate(self):
-        self.opstate = DeviceGroupOpState(self)
-
-    @property
-    def vsys(self):
-        return self.name
-
-    def devicegroup(self):
-        return self
-
-    def xpath_vsys(self):
-        return self.xpath()
-
-    def _setup_opstate(self):
-        self.opstate = DeviceGroupOpState(self)
-
-
-class DeviceGroupOpState(object):
-    """Operational state handling for device group classes."""
-
-    def __init__(self, obj):
-        self.dg_hierarchy = DeviceGroupHierarchy(obj)
-
-
-class DeviceGroupHierarchy(object):
+class DeviceGroupHierarchy(OpState):
     """Operational state handling for device group hierarchy.
 
     Args:
@@ -114,8 +41,7 @@ class DeviceGroupHierarchy(object):
 
     """
 
-    def __init__(self, obj):
-        self.obj = obj
+    def _setup(self):
         self.parent = None
 
     def refresh(self):
@@ -156,6 +82,69 @@ class DeviceGroupHierarchy(object):
         cmd = ET.tostring(e, encoding="utf-8")
         resp = dev.op(cmd, cmd_xml=False)
         return dev.syncjob(resp)
+
+
+class DeviceGroup(VersionedPanObject):
+    """Panorama Device-group
+
+    This class and the :class:`panos.panorama.Panorama` classes are the only objects that can
+    have a :class:`panos.firewall.Firewall` child object. In addition to a Firewall, a
+    DeviceGroup can have the same children objects as a :class:`panos.firewall.Firewall`
+    or :class:`panos.device.Vsys`.
+
+    See also :ref:`classtree`
+
+    Args:
+        name (str): Name of the device-group
+        tag (list): Tags as strings
+
+    """
+
+    ROOT = Root.DEVICE
+    SUFFIX = ENTRY
+    VSYS_LABEL = "device-group"
+    CHILDTYPES = (
+        "firewall.Firewall",
+        "objects.AddressObject",
+        "objects.AddressGroup",
+        "objects.ServiceObject",
+        "objects.ServiceGroup",
+        "objects.ApplicationObject",
+        "objects.ApplicationGroup",
+        "objects.ApplicationFilter",
+        "objects.ScheduleObject",
+        "objects.SecurityProfileGroup",
+        "objects.CustomUrlCategory",
+        "objects.LogForwardingProfile",
+        "objects.Region",
+        "objects.Edl",
+        "policies.PreRulebase",
+        "policies.PostRulebase",
+    )
+    OPSTATES = {
+        "dg_hierarchy": DeviceGroupHierarchy,
+    }
+
+    def _setup(self):
+        # xpaths
+        self._xpaths.add_profile(value="/device-group")
+
+        # params
+        params = []
+
+        params.append(VersionedParamPath("tag", vartype="entry"))
+
+        self._params = tuple(params)
+
+    @property
+    def vsys(self):
+        return self.name
+
+    def devicegroup(self):
+        return self
+
+    def xpath_vsys(self):
+        return self.xpath()
 
 
 class Template(VersionedPanObject):
@@ -375,6 +364,33 @@ class TemplateVariable(VersionedPanObject):
         self._params = tuple(params)
 
 
+class PanoramaDeviceGroupHierarchy(OpState):
+    """Operational state handling for device group hierarchy."""
+
+    def fetch(self):
+        """Returns a dict of device groups and their parents.
+
+        Keys in the dict are the device group's name, while the value is the
+        name of that device group's parent.  Top level device groups will have
+        a parent of ``None``.
+
+        Returns:
+            dict
+
+        """
+
+        resp = self.obj.op("show dg-hierarchy")
+        data = resp.find("./result/dg-hierarchy")
+
+        ans = {}
+        nodes = [(None, x) for x in data.findall("./dg")]
+        for parent, elm in iter(nodes):
+            ans[elm.attrib["name"]] = parent
+            nodes.extend((elm.attrib["name"], x) for x in elm.findall("./dg"))
+
+        return ans
+
+
 class Panorama(base.PanDevice):
     """Panorama device
 
@@ -428,6 +444,9 @@ class Panorama(base.PanDevice):
         "plugins.CloudServicesPlugin",
         "policies.Rulebase",
     )
+    OPSTATES = {
+        "dg_hierarchy": PanoramaDeviceGroupHierarchy,
+    }
 
     def __init__(
         self,
@@ -859,47 +878,6 @@ class Panorama(base.PanDevice):
                     "expires": x.find("./expiry-time").text,
                 }
             )
-
-        return ans
-
-    def _setup_opstate(self):
-        self.opstate = PanoramaOpState(self)
-
-
-class PanoramaOpState(object):
-    """Panorama OP state handling."""
-
-    def __init__(self, obj):
-        self.dg_hierarchy = PanoramaDeviceGroupHierarchy(obj)
-
-
-class PanoramaDeviceGroupHierarchy(object):
-    """Operational state handling for device group hierarchy."""
-
-    def __init__(self, obj):
-        self.obj = obj
-        self.parent = None
-
-    def fetch(self):
-        """Returns a dict of device groups and their parents.
-
-        Keys in the dict are the device group's name, while the value is the
-        name of that device group's parent.  Top level device groups will have
-        a parent of ``None``.
-
-        Returns:
-            dict
-
-        """
-
-        resp = self.obj.op("show dg-hierarchy")
-        data = resp.find("./result/dg-hierarchy")
-
-        ans = {}
-        nodes = [(None, x) for x in data.findall("./dg")]
-        for parent, elm in iter(nodes):
-            ans[elm.attrib["name"]] = parent
-            nodes.extend((elm.attrib["name"], x) for x in elm.findall("./dg"))
 
         return ans
 

--- a/panos/policies.py
+++ b/panos/policies.py
@@ -18,15 +18,135 @@
 """Policies module contains policies and rules that exist in the 'Policies' tab in the firewall GUI"""
 
 import xml.etree.ElementTree as ET
-from datetime import datetime
 
 import panos.errors as err
 from panos import getlogger
-from panos.base import ENTRY, MEMBER, PanObject, Root
+from panos.base import ENTRY, MEMBER, OpState, PanObject, Root
 from panos.base import VarPath as Var
 from panos.base import VersionedPanObject, VersionedParamPath
 
 logger = getlogger(__name__)
+
+
+class HitCount(OpState):
+    """Hit count operational data."""
+
+    FIELDS = (
+        ("latest", "latest", "str"),
+        ("hit_count", "hit-count", "int"),
+        ("last_hit_timestamp", "last-hit-timestamp", "int"),
+        ("last_reset_timestamp", "last-reset-timestamp", "int"),
+        ("first_hit_timestamp", "first-hit-timestamp", "int"),
+        ("rule_creation_timestamp", "rule-creation-timestamp", "int"),
+        ("rule_modification_timestamp", "rule-modification-timestamp", "int"),
+    )
+
+    def _setup(self, name=None, elm=None):
+        self.name = name if self.obj is None else self.obj.uid
+        self._refresh_xml(elm)
+
+    def refresh(self, elm=None):
+        if elm is None and self.obj is not None:
+            self.obj.parent.opstate.hit_count.refresh(
+                self.obj.HIT_COUNT_STYLE, [self.name,],
+            )
+        else:
+            self._refresh_xml(elm)
+
+    def _refresh_xml(self, elm):
+        for param, path, param_type in self.FIELDS:
+            if param_type == "int":
+                setattr(self, param, self._int(elm, path))
+            else:
+                setattr(self, param, self._str(elm, path))
+
+
+class AuditCommentLog(OpState):
+    """A single audit comment log entry."""
+
+    def __init__(self, elm):
+        self.admin = self._str(elm, "admin")
+        self.comment = self._str(elm, "comment")
+        self.config_version = self._int(elm, "config_ver")
+        self.time = self._datetime(elm, "time_generated", "%Y/%m/%d %H:%M:%S")
+
+
+class RulebaseHitCount(OpState):
+    """Operational state handling for rulebase hit counts."""
+
+    def refresh(self, style, rules=None, all_rules=False):
+        """Retrieves hit count information for the specified rules.
+
+        PAN-OS 8.1+
+
+        Args:
+            style (str): The rule style to use.  The style can be
+                "application-override", "authentication", "decryption", "dos",
+                "nat", "pbf", "qos", "sdwan", "security", or "tunnel-inspect".
+            rules (list): A list of rules.  This can be a mix of `panos.policies`
+                instances or basic strings.  If no rules are given, then the hit
+                count for all rules is retrieved.
+            all_rules (bool): If this is False, only retrieve hit count information
+                for the rules attached to the rulebase of the specified style.  If
+                this is True, then get all rules.  Either way, any rule whose hit count
+                is retrieved and is in the object hierarchy has the hit count data
+                saved to its `opstate`.
+
+        Returns:
+            dict:  A dict where the key is the rule name and the value is the hit count information.
+
+        """
+        dev = self.obj.nearest_pandevice()
+
+        if dev.retrieve_panos_version() < (8, 1, 0):
+            raise err.PanDeviceError("Rule hit count is supported in PAN-OS 8.1+")
+
+        kids = []
+        for x in self.obj.children:
+            if not hasattr(x, "HIT_COUNT_STYLE") or x.HIT_COUNT_STYLE != style:
+                continue
+            if rules is None or x.uid in rules:
+                kids.append(x)
+
+        cmd = ET.Element("show")
+        sub = ET.SubElement(cmd, "rule-hit-count")
+        sub = ET.SubElement(sub, "vsys")
+        sub = ET.SubElement(sub, "vsys-name")
+        sub = ET.SubElement(sub, "entry", {"name": dev.vsys or "vsys1"})
+        sub = ET.SubElement(sub, "rule-base")
+        sub = ET.SubElement(sub, "entry", {"name": style})
+        sub = ET.SubElement(sub, "rules")
+
+        if all_rules:
+            ET.SubElement(sub, "all")
+        else:
+            # Loop over rules specified or the object hierarchy.
+            rule_list = rules or kids or []
+            if not rule_list:
+                return {}
+            sub = ET.SubElement(sub, "list")
+            for x in rule_list:
+                if hasattr(x, "uid"):
+                    ET.SubElement(sub, "member").text = x.uid
+                else:
+                    ET.SubElement(sub, "member").text = x
+
+        res = dev.op(ET.tostring(cmd, encoding="utf-8"), cmd_xml=False)
+
+        ans = {}
+        for elm in res.findall(
+            "./result/rule-hit-count/vsys/entry/rule-base/entry/rules/entry"
+        ):
+            name = elm.attrib["name"]
+            for x in kids:
+                if x.uid == name:
+                    x.opstate.hit_count.refresh(elm)
+                    ans[name] = x.opstate.hit_count
+                    break
+            else:
+                ans[name] = HitCount(None, name=name, elm=elm)
+
+        return ans
 
 
 class Rulebase(VersionedPanObject):
@@ -39,6 +159,9 @@ class Rulebase(VersionedPanObject):
 
     NAME = None
     ROOT = Root.VSYS
+    OPSTATES = {
+        "hit_count": RulebaseHitCount,
+    }
     CHILDTYPES = (
         "policies.NatRule",
         "policies.PolicyBasedForwarding",
@@ -49,9 +172,6 @@ class Rulebase(VersionedPanObject):
 
     def _setup(self):
         self._xpaths.add_profile(value="/rulebase")
-
-    def _setup_opstate(self):
-        self.opstate = RulebaseOpState(self)
 
 
 class PreRulebase(Rulebase):
@@ -74,6 +194,97 @@ class PostRulebase(Rulebase):
 
     def _setup(self):
         self._xpaths.add_profile(value="/post-rulebase")
+
+
+class RuleAuditComment(OpState):
+    """Operational state handling for a rule's audit comments.
+
+    Note:  Audit comments are present in PAN-OS 9.0+.
+
+    """
+
+    def history(self, count=100, direction="backward", skip=None):
+        """Returns a chunk of historical audit comment logs.
+
+        Args:
+            count (int): Number of audit comments to return, maximum 5000.
+            direction (str): Specify whether logs are shown oldest first
+                (``forward``) or newest first (``backward``).
+            skip (int): Specify the number of logs to skip when doing log
+                retrieval.  This is useful when retrieving logs in batches
+                where you can skip the previously retrieved logs.
+
+        Returns:
+            list of :class:`panos.policies.AuditCommentLog`
+
+        """
+        dev = self.obj.nearest_pandevice()
+
+        # Build up the query.
+        query = "(subtype eq audit-comment)"
+        # Add in the name.
+        query += " and (path contains '\\'{0}\\'')".format(self.obj.uid)
+        # Add in the rule type.
+        query += " and (path contains '{0}')".format(
+            self.obj.xpath_short().split("/")[-2],
+        )
+        # Add in the rulebase type.
+        p = self.obj.parent
+        if p is None:
+            raise err.PanDeviceError("rule has empty parent")
+        if not any(isinstance(p, x) for x in (Rulebase, PreRulebase, PostRulebase)):
+            raise err.PanDeviceError("{0} has non-rulebase parent".format(self.obj.uid))
+        query += " and (path contains {0})".format(p.xpath().split("/")[-1])
+        # Add in the vsys or device group.
+        query += " and (path contains '\\'{0}\\'')".format(p.vsys)
+
+        extra_qs = {
+            "dir": direction,
+            "uniq": "yes",
+        }
+        if skip is not None:
+            extra_qs["skip"] = "{0}".format(int(skip))
+
+        resp = dev.xapi.log("config", count, filter=query, extra_qs=extra_qs)
+
+        return [AuditCommentLog(x) for x in resp.findall("./result/log/logs/entry")]
+
+    def current(self):
+        """Returns the current audit comment.
+
+        Returns:
+            string
+
+        """
+        cmd = ET.Element("show")
+        sub = ET.SubElement(cmd, "config")
+        sub = ET.SubElement(sub, "list")
+        sub = ET.SubElement(sub, "audit-comments")
+        ET.SubElement(sub, "xpath").text = self.obj.xpath()
+
+        ans = self.obj.nearest_pandevice().op(
+            ET.tostring(cmd, encoding="utf-8"), cmd_xml=False,
+        )
+
+        resp = ans.find("./result/entry/comment")
+        if resp is not None:
+            return resp.text
+
+    def update(self, comment):
+        """Sets an audit comment for the given rule.
+
+        Args:
+            comment (str): The audit comment.
+
+        """
+        cmd = ET.Element("set")
+        sub = ET.SubElement(cmd, "audit-comment")
+        ET.SubElement(sub, "xpath").text = self.obj.xpath()
+        ET.SubElement(sub, "comment").text = comment
+
+        self.obj.nearest_pandevice().op(
+            ET.tostring(cmd, encoding="utf-8"), cmd_xml=False,
+        )
 
 
 class SecurityRule(VersionedPanObject):
@@ -134,6 +345,10 @@ class SecurityRule(VersionedPanObject):
     SUFFIX = ENTRY
     ROOT = Root.VSYS
     HIT_COUNT_STYLE = "security"
+    OPSTATES = {
+        "audit_comment": RuleAuditComment,
+        "hit_count": HitCount,
+    }
 
     def _setup(self):
         # xpaths
@@ -243,9 +458,6 @@ class SecurityRule(VersionedPanObject):
 
         self._params = tuple(params)
 
-    def _setup_opstate(self):
-        self.opstate = RuleOpState(self)
-
 
 class NatRule(VersionedPanObject):
     """NAT Rule
@@ -319,6 +531,10 @@ class NatRule(VersionedPanObject):
     SUFFIX = ENTRY
     ROOT = Root.VSYS
     HIT_COUNT_STYLE = "nat"
+    OPSTATES = {
+        "audit_comment": RuleAuditComment,
+        "hit_count": HitCount,
+    }
 
     def _setup(self):
         # xpaths
@@ -604,9 +820,6 @@ class NatRule(VersionedPanObject):
 
         self._params = tuple(params)
 
-    def _setup_opstate(self):
-        self.opstate = RuleOpState(self)
-
 
 class ApplicationOverride(VersionedPanObject):
     """ApplicationOverride
@@ -637,6 +850,10 @@ class ApplicationOverride(VersionedPanObject):
     SUFFIX = ENTRY
     ROOT = Root.VSYS
     HIT_COUNT_STYLE = "application-override"
+    OPSTATES = {
+        "audit_comment": RuleAuditComment,
+        "hit_count": HitCount,
+    }
 
     def _setup(self):
         # xpaths
@@ -681,9 +898,6 @@ class ApplicationOverride(VersionedPanObject):
         params[-1].add_profile("9.0.0", path="group-tag")
 
         self._params = tuple(params)
-
-    def _setup_opstate(self):
-        self.opstate = RuleOpState(self)
 
 
 class PolicyBasedForwarding(VersionedPanObject):
@@ -735,6 +949,10 @@ class PolicyBasedForwarding(VersionedPanObject):
     SUFFIX = ENTRY
     ROOT = Root.VSYS
     HIT_COUNT_STYLE = "pbf"
+    OPSTATES = {
+        "audit_comment": RuleAuditComment,
+        "hit_count": HitCount,
+    }
 
     def _setup(self):
         # xpaths
@@ -875,9 +1093,6 @@ class PolicyBasedForwarding(VersionedPanObject):
 
         self._params = tuple(params)
 
-    def _setup_opstate(self):
-        self.opstate = RuleOpState(self)
-
 
 class DecryptionRule(VersionedPanObject):
     """Decryption rule.
@@ -923,6 +1138,10 @@ class DecryptionRule(VersionedPanObject):
     SUFFIX = ENTRY
     ROOT = Root.VSYS
     HIT_COUNT_STYLE = "decryption"
+    OPSTATES = {
+        "audit_comment": RuleAuditComment,
+        "hit_count": HitCount,
+    }
 
     def _setup(self):
         # xpaths
@@ -1031,265 +1250,3 @@ class DecryptionRule(VersionedPanObject):
         )
 
         self._params = tuple(params)
-
-    def _setup_opstate(self):
-        self.opstate = RuleOpState(self)
-
-
-class RulebaseOpState(object):
-    """Operational state handling for rulebase classes."""
-
-    def __init__(self, obj):
-        self.hit_count = RulebaseHitCount(obj)
-
-
-class RulebaseHitCount(object):
-    """Operational state handling for rulebase hit counts."""
-
-    def __init__(self, obj):
-        self.obj = obj
-
-    def refresh(self, style, rules=None, all_rules=False):
-        """Retrieves hit count information for the specified rules.
-
-        PAN-OS 8.1+
-
-        Args:
-            style (str): The rule style to use.  The style can be
-                "application-override", "authentication", "decryption", "dos",
-                "nat", "pbf", "qos", "sdwan", "security", or "tunnel-inspect".
-            rules (list): A list of rules.  This can be a mix of `panos.policies`
-                instances or basic strings.  If no rules are given, then the hit
-                count for all rules is retrieved.
-            all_rules (bool): If this is False, only retrieve hit count information
-                for the rules attached to the rulebase of the specified style.  If
-                this is True, then get all rules.  Either way, any rule whose hit count
-                is retrieved and is in the object hierarchy has the hit count data
-                saved to its `opstate`.
-
-        Returns:
-            dict:  A dict where the key is the rule name and the value is the hit count information.
-
-        """
-        dev = self.obj.nearest_pandevice()
-
-        if dev.retrieve_panos_version() < (8, 1, 0):
-            raise err.PanDeviceError("Rule hit count is supported in PAN-OS 8.1+")
-
-        kids = []
-        for x in self.obj.children:
-            if not hasattr(x, "HIT_COUNT_STYLE") or x.HIT_COUNT_STYLE != style:
-                continue
-            if rules is None or x.uid in rules:
-                kids.append(x)
-
-        cmd = ET.Element("show")
-        sub = ET.SubElement(cmd, "rule-hit-count")
-        sub = ET.SubElement(sub, "vsys")
-        sub = ET.SubElement(sub, "vsys-name")
-        sub = ET.SubElement(sub, "entry", {"name": dev.vsys or "vsys1"})
-        sub = ET.SubElement(sub, "rule-base")
-        sub = ET.SubElement(sub, "entry", {"name": style})
-        sub = ET.SubElement(sub, "rules")
-
-        if all_rules:
-            ET.SubElement(sub, "all")
-        else:
-            # Loop over rules specified or the object hierarchy.
-            rule_list = rules or kids or []
-            if not rule_list:
-                return {}
-            sub = ET.SubElement(sub, "list")
-            for x in rule_list:
-                if hasattr(x, "uid"):
-                    ET.SubElement(sub, "member").text = x.uid
-                else:
-                    ET.SubElement(sub, "member").text = x
-
-        res = dev.op(ET.tostring(cmd, encoding="utf-8"), cmd_xml=False)
-
-        ans = {}
-        for elm in res.findall(
-            "./result/rule-hit-count/vsys/entry/rule-base/entry/rules/entry"
-        ):
-            name = elm.attrib["name"]
-            for x in kids:
-                if x.uid == name:
-                    x.opstate.hit_count.refresh(elm)
-                    ans[name] = x.opstate.hit_count
-                    break
-            else:
-                ans[name] = HitCount(name=name, elm=elm)
-
-        return ans
-
-
-class OpStateObject(object):
-    """A container object for opstate data."""
-
-    def _str(self, elm, field):
-        if elm is not None:
-            val = elm.find("./{0}".format(field))
-            if val is not None:
-                return val.text
-
-    def _int(self, elm, field):
-        val = self._str(elm, field)
-        if val is not None:
-            return int(val)
-
-    def _datetime(self, elm, field, fmt):
-        val = self._str(elm, field)
-        if val is not None:
-            try:
-                return datetime.strptime(val, fmt)
-            except ValueError:
-                pass
-            return val
-
-
-class HitCount(OpStateObject):
-    """Hit count operational data."""
-
-    FIELDS = (
-        ("latest", "latest", "str"),
-        ("hit_count", "hit-count", "int"),
-        ("last_hit_timestamp", "last-hit-timestamp", "int"),
-        ("last_reset_timestamp", "last-reset-timestamp", "int"),
-        ("first_hit_timestamp", "first-hit-timestamp", "int"),
-        ("rule_creation_timestamp", "rule-creation-timestamp", "int"),
-        ("rule_modification_timestamp", "rule-modification-timestamp", "int"),
-    )
-
-    def __init__(self, obj=None, name=None, elm=None):
-        self.obj = obj
-        self.name = name if obj is None else obj.uid
-        self._refresh_xml(elm)
-
-    def refresh(self, elm=None):
-        if elm is None and self.obj is not None:
-            self.obj.parent.opstate.hit_count.refresh(
-                self.obj.HIT_COUNT_STYLE, [self.name,],
-            )
-        else:
-            self._refresh_xml(elm)
-
-    def _refresh_xml(self, elm):
-        for param, path, param_type in self.FIELDS:
-            if param_type == "int":
-                setattr(self, param, self._int(elm, path))
-            else:
-                setattr(self, param, self._str(elm, path))
-
-
-class RuleOpState(object):
-    """Operational state handling for a rule in the rulebase."""
-
-    def __init__(self, obj):
-        self.obj = obj
-        self.audit_comment = RuleAuditComment(obj)
-        self.hit_count = HitCount(obj)
-
-
-class RuleAuditComment(object):
-    """Operational state handling for a rule's audit comments.
-
-    Note:  Audit comments are present in PAN-OS 9.0+.
-
-    """
-
-    def __init__(self, obj):
-        self.obj = obj
-
-    def history(self, count=100, direction="backward", skip=None):
-        """Returns a chunk of historical audit comment logs.
-
-        Args:
-            count (int): Number of audit comments to return, maximum 5000.
-            direction (str): Specify whether logs are shown oldest first
-                (``forward``) or newest first (``backward``).
-            skip (int): Specify the number of logs to skip when doing log
-                retrieval.  This is useful when retrieving logs in batches
-                where you can skip the previously retrieved logs.
-
-        Returns:
-            list of :class:`panos.policies.AuditCommentLog`
-
-        """
-        dev = self.obj.nearest_pandevice()
-
-        # Build up the query.
-        query = "(subtype eq audit-comment)"
-        # Add in the name.
-        query += " and (path contains '\\'{0}\\'')".format(self.obj.uid)
-        # Add in the rule type.
-        query += " and (path contains '{0}')".format(
-            self.obj.xpath_short().split("/")[-2],
-        )
-        # Add in the rulebase type.
-        p = self.obj.parent
-        if p is None:
-            raise err.PanDeviceError("rule has empty parent")
-        if not any(isinstance(p, x) for x in (Rulebase, PreRulebase, PostRulebase)):
-            raise err.PanDeviceError("{0} has non-rulebase parent".format(self.obj.uid))
-        query += " and (path contains {0})".format(p.xpath().split("/")[-1])
-        # Add in the vsys or device group.
-        query += " and (path contains '\\'{0}\\'')".format(p.vsys)
-
-        extra_qs = {
-            "dir": direction,
-            "uniq": "yes",
-        }
-        if skip is not None:
-            extra_qs["skip"] = "{0}".format(int(skip))
-
-        resp = dev.xapi.log("config", count, filter=query, extra_qs=extra_qs)
-
-        return [AuditCommentLog(x) for x in resp.findall("./result/log/logs/entry")]
-
-    def current(self):
-        """Returns the current audit comment.
-
-        Returns:
-            string
-
-        """
-        cmd = ET.Element("show")
-        sub = ET.SubElement(cmd, "config")
-        sub = ET.SubElement(sub, "list")
-        sub = ET.SubElement(sub, "audit-comments")
-        ET.SubElement(sub, "xpath").text = self.obj.xpath()
-
-        ans = self.obj.nearest_pandevice().op(
-            ET.tostring(cmd, encoding="utf-8"), cmd_xml=False,
-        )
-
-        resp = ans.find("./result/entry/comment")
-        if resp is not None:
-            return resp.text
-
-    def update(self, comment):
-        """Sets an audit comment for the given rule.
-
-        Args:
-            comment (str): The audit comment.
-
-        """
-        cmd = ET.Element("set")
-        sub = ET.SubElement(cmd, "audit-comment")
-        ET.SubElement(sub, "xpath").text = self.obj.xpath()
-        ET.SubElement(sub, "comment").text = comment
-
-        self.obj.nearest_pandevice().op(
-            ET.tostring(cmd, encoding="utf-8"), cmd_xml=False,
-        )
-
-
-class AuditCommentLog(OpStateObject):
-    """A single audit comment log entry."""
-
-    def __init__(self, elm):
-        self.admin = self._str(elm, "admin")
-        self.comment = self._str(elm, "comment")
-        self.config_version = self._int(elm, "config_ver")
-        self.time = self._datetime(elm, "time_generated", "%Y/%m/%d %H:%M:%S")

--- a/tests/test_opstate.py
+++ b/tests/test_opstate.py
@@ -121,7 +121,7 @@ def test_rulebase_hit_count_refresh_for_single_attached_security_rule():
         rule_creation_timestamp=1599752499,
         rule_modification_timestamp=1599752499,
     )
-    expected = HitCount(name=name, elm=elm)
+    expected = HitCount(None, name=name, elm=elm)
 
     fw, rb = _hit_count_fw_setup(elm)
     o = SecurityRule(name)
@@ -145,7 +145,7 @@ def test_rulebase_hit_count_refresh_for_multiple_attached_security_rules():
         rule_creation_timestamp=1599752499,
         rule_modification_timestamp=1599752499,
     )
-    e1 = HitCount(name=n1, elm=elm1)
+    e1 = HitCount(None, name=n1, elm=elm1)
 
     n2 = "bar"
     elm2 = _hit_count_elm(
@@ -154,7 +154,7 @@ def test_rulebase_hit_count_refresh_for_multiple_attached_security_rules():
         rule_creation_timestamp=1234,
         rule_modification_timestamp=5678,
     )
-    e2 = HitCount(name=n2, elm=elm2)
+    e2 = HitCount(None, name=n2, elm=elm2)
 
     fw, rb = _hit_count_fw_setup(elm1, elm2)
     o1 = SecurityRule(n1)
@@ -185,7 +185,7 @@ def test_rulebase_hit_count_refresh_for_all_rules_updates_attached_rule():
         rule_creation_timestamp=1599752499,
         rule_modification_timestamp=1599752499,
     )
-    e1 = HitCount(name=n1, elm=elm1)
+    e1 = HitCount(None, name=n1, elm=elm1)
 
     n2 = "interzone-default"
     elm2 = _hit_count_elm(
@@ -194,7 +194,7 @@ def test_rulebase_hit_count_refresh_for_all_rules_updates_attached_rule():
         rule_creation_timestamp=1599752499,
         rule_modification_timestamp=1599752499,
     )
-    e2 = HitCount(name=n2, elm=elm2)
+    e2 = HitCount(None, name=n2, elm=elm2)
 
     name = "bar"
     elm3 = _hit_count_elm(
@@ -203,7 +203,7 @@ def test_rulebase_hit_count_refresh_for_all_rules_updates_attached_rule():
         rule_creation_timestamp=1234,
         rule_modification_timestamp=5678,
     )
-    expected = HitCount(name=name, elm=elm3)
+    expected = HitCount(None, name=name, elm=elm3)
 
     fw, rb = _hit_count_fw_setup(elm1, elm2, elm3)
     o = SecurityRule(name)
@@ -234,7 +234,7 @@ def test_security_rule_hit_count_refresh():
         rule_creation_timestamp=24,
         rule_modification_timestamp=25,
     )
-    expected = HitCount(name=name, elm=elm)
+    expected = HitCount(None, name=name, elm=elm)
 
     fw, rb = _hit_count_fw_setup(elm)
     o = SecurityRule(name)

--- a/tests/test_standards.py
+++ b/tests/test_standards.py
@@ -491,3 +491,17 @@ def test_parent_aware_children_show_in_parent_childtypes(versioned_object):
         assert panos.childtype_name(versioned_object) in cls.CHILDTYPES, msg.format(
             versioned_object, cls
         )
+
+
+def test_opstates_is_a_dict(panobj):
+    assert isinstance(getattr(panobj, "OPSTATES", {}), dict)
+
+
+def test_opstates_inherit_from_opstate(panobj):
+    for name, cls in panobj.OPSTATES.items():
+        mro = inspect.getmro(cls)
+        assert (
+            base.OpState in mro
+        ), "base.OpState is not in the {0}.opstate.{1} mro".format(
+            panobj.__name__, name
+        )


### PR DESCRIPTION
This condenses the opstate namespace into its own class, and adds
an `.about()`.  This means that `.opstate` will always exist
(as opposed to just if there are functions there or not).

Work on #396
