### PR TITLE
fix: `delete_similar()` now breaks delete calls into chunks

### DIFF
--- a/panos/__init__.py
+++ b/panos/__init__.py
@@ -510,3 +510,20 @@ def parents_for(cls, classes):
         for ctn, x in classes.items()
         if childtype_name(cls) in getattr(x, "CHILDTYPES", [])
     ]
+
+
+def chunk_instances_for_delete_similar(instances):
+    start = 0
+    chunks = []
+    cur_length = 0
+
+    for end, x in enumerate(instances):
+        if cur_length >= 25000:
+            chunks.append(instances[start:end])
+            start = end
+            cur_length = 0
+        cur_length += len(x.uid) + 8 + 4
+
+    chunks.append(instances[start:])
+
+    return chunks


### PR DESCRIPTION
Some testing of PAN-OS responsiveness has lead to the discovery that
a `delete()` API call of around 25k characters can take anywhere
from 3.3sec to 15sec, depending on the load.  All pan-os-python API
calls are expected to complete within 30sec by default.  If the API
call takes longer than that to complete, then the call times out
and the delete doesn't seem to take.

Thus, `delete_similar()` will now break deletes into chunks of
around 25k characters.
