### PR TITLE
[ISSUE-441]  Added Makefile support for local env setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean-pyc clean-build docs clean
+.PHONY: clean-pyc clean-build docs clean local-setup
 
 help:
 	@echo "clean - remove all build, test, coverage and Python artifacts"
@@ -16,6 +16,7 @@ help:
 	@echo "release - package and upload a release"
 	@echo "dist - package"
 	@echo "sync-deps - save dependencies to requirements.txt"
+	@echo "local-setup - sets up a linux or macos local directory for contribution by installing poetry and requirements"
 
 clean: clean-build clean-pyc clean-test clean-docs
 
@@ -57,6 +58,9 @@ check-format:
 test:
 	pytest
 
+test-simple:
+	pytest --disable-warnings
+
 test-all:
 	tox
 
@@ -80,3 +84,14 @@ sync-deps:
 	poetry export -f requirements.txt > requirements.txt
 	dephell deps convert
 	black setup.py
+
+local-setup:
+ifeq ($(wildcard ~/.local/bin/poetry),)
+	@echo "installing poetry"
+	curl -sSL https://install.python-poetry.org | python3 -
+else
+	@echo "poetry installation found"
+endif
+	~/.local/bin/poetry install
+
+	

--- a/panos/policies.py
+++ b/panos/policies.py
@@ -311,7 +311,7 @@ class SecurityRule(VersionedPanObject):
         tozone (list): To zones
         source (list): Source addresses
         source_user (list): Source users and groups
-        hip_profiles (list): GlobalProtect host integrity profiles
+        hip_profiles (list): (PAN-OS 10.1.4-) GlobalProtect host integrity profiles
         destination (list): Destination addresses
         application (list): Applications
         service (list): Destination services (ports) (Default:
@@ -377,7 +377,22 @@ class SecurityRule(VersionedPanObject):
             ("tozone", "to"),
             ("source", "source"),
             ("source_user", "source-user"),
-            ("hip_profiles", "hip-profiles"),
+        )
+        for var_name, path in any_defaults:
+            params.append(
+                VersionedParamPath(
+                    var_name, default=["any",], vartype="member", path=path
+                )
+            )
+        # this is hokey, but we have to preserve the ordering of the
+        # parameters in case callers specified `hip_profiles` positionally
+        # and not as a kwarg.
+        params.append(VersionedParamPath(
+            "hip_profiles",
+            default=["any",]))
+        params[-1].add_profile("0.0.0", vartype="member", path="hip-profiles")
+        params[-1].add_profile("10.1.5", exclude=True)
+        any_defaults = (
             ("destination", "destination"),
             ("application", "application"),
         )

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -2,6 +2,7 @@ try:
     from unittest import mock
 except ImportError:
     import mock
+import re
 import unittest
 import xml.etree.ElementTree as ET
 
@@ -300,6 +301,27 @@ class TestVersionedObject(unittest.TestCase):
         self,
     ):
         self.assertRaises(ValueError, self.obj.add_profile, "5.5.5", "foo")
+
+
+def test_security_rule_hip_profiles():
+    "security rules on 10.1.5 should not have hip-profiles"
+    rule = panos.policies.SecurityRule(
+        name="test_rule",
+        source=["0.0.0.0/0"],
+        destination=["0.0.0.0/0"],
+    )
+    rule._UNKNOWN_PANOS_VERSION = (10, 1, 5)
+    st = rule.element_str(False).decode()
+    assert '<hip-profiles>' not in st
+
+    rule = panos.policies.SecurityRule(
+        name="test_rule",
+        source=["0.0.0.0/0"],
+        destination=["0.0.0.0/0"],
+    )
+    rule._UNKNOWN_PANOS_VERSION = (9, 0, 0)
+    st = rule.element_str(False).decode()
+    assert '<hip-profiles><member>any</member></hip-profiles>' in st
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added versioning support for hip-profiles since `hip-profiles` is no
longer supported in v10.1.5+

## Description

Adds versioning for `hip_profiles` when creating a security rule.

## Motivation and Context

Please see issue 441

## How Has This Been Tested?

Added unit tests to make sure that version 10.1.5+ xml included no `hip-profiles` element while lower versions still maintained the value.


## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist


- [ X ] I have updated the documentation accordingly.
- [ X ] I have read the **CONTRIBUTING** document.
- [ X ] I have added tests to cover my changes if appropriate.
- [ X ] All new and existing tests passed.
