### PR TITLE
Fix formatting of `request system software install` command - load_config parameter

### DIFF
--- a/panos/updater.py
+++ b/panos/updater.py
@@ -120,9 +120,9 @@ class SoftwareUpdater(Updater):
             "Device %s installing version: %s" % (self.pandevice.id, version)
         )
         response = self._op(
-            'request system software install%s version "%s"'
+            'request system software install %s version "%s"'
             % (
-                " load-config " + load_config if load_config is not None else "",
+                'load-config "{0}"'.format(load_config) if load_config else "",
                 version,
             )
         )

--- a/panos/updater.py
+++ b/panos/updater.py
@@ -121,10 +121,7 @@ class SoftwareUpdater(Updater):
         )
         response = self._op(
             'request system software install %s version "%s"'
-            % (
-                'load-config "{0}"'.format(load_config) if load_config else "",
-                version,
-            )
+            % ('load-config "{0}"'.format(load_config) if load_config else "", version,)
         )
         if sync:
             result = self.pandevice.syncjob(response)


### PR DESCRIPTION
## Description

The command triggered in `SoftwareUpdater.install()` method has wrong formatting around `load_config` parameter. All non key words should be quoted, this includes the value of `load_config` ([see `op` method documentation](https://github.com/PaloAltoNetworks/pan-os-python/blob/20dd7b7ecd710b824a97416f849d6084436ef57f/panos/base.py#L4018-L4020)).

For the moment the `load_config` parameter is not quoted which causes the `op` method to fail.

## Motivation and Context

W/o this fix running an upgrade with named configuration load after reboot is not possible.

## How Has This Been Tested?

This fix was used in an Ansible playbook.

## Screenshots (if appropriate)

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
