### PR TITLE
Do not add layer2 interfaces to a virtual router

### DIFF
--- a/panos/network.py
+++ b/panos/network.py
@@ -426,8 +426,8 @@ class Interface(VsysOperations):
             Zone: The zone for this interface after the operation completes
 
         """
-        # Don't add HA or aggregate-group interfaces to virtual router.
-        if getattr(self, "mode", "") in ("ha", "aggregate-group"):
+        # Don't add HA, aggregate-group, and layer2 interfaces to virtual router.
+        if getattr(self, "mode", "") in ("ha", "aggregate-group", "layer2"):
             return False
 
         return self._set_reference(


### PR DESCRIPTION
## Description

Prevent `layer2` interfaces being added to virtual routers

## Motivation and Context

The origin of this PR stems downstream from `pan-os-ansible`, where adding a aggregate interface with mode set to `layer2` results in an error. This error seems to be due to the network module trying to add the `layer2` interface to a virtual-router.

**code example**
```yaml
- panos_aggregate_interface:
    if_name: "ae2"
    mode: layer2
    lacp_enable: True
    lldp_enabled: True
    lldp_profile: default
    commit: False
```

As `layer2` interfaces do not have any routable properties, and cannot be added to a virtual-router in the PAN-OS interface, they should be excluded.

**downstream error message**
```
The full traceback is:
  File "/tmp/ansible_panos_aggregate_interface_payload_8n5bzkkx/ansible_panos_aggregate_interface_payload.zip/ansible_collections/paloaltonetworks/panos/plugins/modules/panos_aggregate_interface.py", line 297, in main
  File "/home/mvandam/.local/lib/python3.10/site-packages/panos/network.py", line 433, in set_virtual_router
    return self._set_reference(
  File "/home/mvandam/.local/lib/python3.10/site-packages/panos/base.py", line 1664, in _set_reference
    obj.update(reference_var)
  File "/home/mvandam/.local/lib/python3.10/site-packages/panos/base.py", line 712, in update
    device.xapi.edit(
  File "/home/mvandam/.local/lib/python3.10/site-packages/panos/base.py", line 3899, in method
    raise the_exception
fatal: [fra01.lsvpn-hub.leaseweb.org]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "adjust_tcp_mss": null,
            "api_key": null,
            "comment": null,
            "commit": false,
            "create_dhcp_default_route": null,
            "dhcp_default_route_metric": null,
            "enable_dhcp": null,
            "if_name": "ae2",
            "ip": null,
            "ip_address": null,
            "ipv4_mss_adjust": null,
            "ipv6_enabled": null,
            "ipv6_mss_adjust": null,
            "lacp_enable": true,
            "lacp_mode": null,
            "lacp_passive_pre_negotiation": null,
            "lacp_rate": null,
            "lldp_enabled": true,
            "lldp_profile": "default",
            "management_profile": null,
            "mode": "layer2",
            "mtu": null,
            "netflow_profile": null,
            "password": null,
            "port": 443,
            "provider": {},
            "state": "present",
            "template": null,
            "username": "admin",
            "vr_name": "default",
            "vsys": null,
            "zone_name": null
        }
    },
    "msg": "Failed setref:  interface 'ae2' is not a valid reference"
}
```

## How Has This Been Tested?

I have tested and can confirm that `layer2` and `layer3` aggregate interfaces are now correctly deployed. This has been tested against PAN-OS 10.1.6 

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
