### PR TITLE
Fixes #463. Expose LLDP neighbors on EthernetInterface

### DIFF
--- a/panos/network.py
+++ b/panos/network.py
@@ -496,6 +496,41 @@ class Interface(VsysOperations):
             False,
         )
 
+    def get_lldp_neighbors(self):
+        """Pull the LLDP neighbors for an interface
+
+        Returns:
+            list of dicts with keys ['chassis-type', 'chassis-id', 'port-type',
+                                     'port-id', 'port-description', 'ttl',
+                                     'system-name', 'system-description',
+                                     'system-capabilities',
+                                     'enabled-capabilities',
+                                     ]
+
+        """
+        from pan.config import PanConfig
+        if not self.lldp_enabled:
+            logger.debug("not fetching lldp neighbors from %s as lldp is not enabled", self.name)
+            return []
+
+        device = self.nearest_pandevice()
+        cmd = 'show lldp neighbors "{0}"'.format(self.name)
+        pconf = device.op(cmd)
+        pconf = PanConfig(pconf)
+        response = pconf.python()
+        logger.debug("response: " + str(response))
+        neighbors = response["response"]["result"]["entry"][0].get("neighbors")
+
+        if neighbors is None:
+            return []
+
+        for e in entries:
+            e.pop("name", None)
+            e.pop("management-address", None)
+
+        return neighbors["entry"]
+
+
     def get_counters(self):
         """Pull the counters for an interface
 


### PR DESCRIPTION
## Description

This change adds a new function: `get_lldp_neighbors` to `EthernetInterface`, which returns a list of LLDP neighbors from the device.

## Motivation and Context
LLDP is very useful to determine whether patching was carried out correctly, see #463 

## How Has This Been Tested?
I am testing this on a PA-850.

Lint rules from the contributing guidelines were broken prior to this change

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.


I have not added tests, I couldn't find a test for `get_counters` to base my test on, is there a similar test I can use as an example?