### PR TITLE
Fix for None datatype in _parse_job_results()

### DIFF
--- a/panos/base.py
+++ b/panos/base.py
@@ -5129,7 +5129,7 @@ class PanDevice(PanObject):
         else:
             try:
                 messages = job["details"]["line"]
-            except KeyError:
+            except (TypeError, KeyError):
                 messages = []
         if isstring(messages):
             messages = string_or_list(messages)


### PR DESCRIPTION
## Description

Adding an exception handler to catch datatype errors with jobs where details is None.  

## Motivation and Context

Resolve bug described in #470

## How Has This Been Tested?

The command that encountered the issue were rerun and the response was successful. 
``` python
download_cmd = "<request><plugins><download><file>vm_series-2.1.2</file></download></plugins></request>"
download_response = parent.op(download_cmd, cmd_xml=False)
download_result = parent.syncjob(download_response)
```

Successful download response
``` json
{
   "success":true,
   "result":"OK",
   "jobid":"18",
   "user":"None",
   "warnings":"None",
   "starttime":"2022/07/26 08:58:18",
   "endtime":"08:58:19",
   "messages":[
      
   ],
   "devices":{
      
   },
   "xml":"<Element""response"at 0x7f68569ca180>
}
```

Tested against panos 9.1 using the pan-os-python poetry venv. 
This is very small and self contained change and won't affect other parts of the code base.  

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

~~- [ ] I have updated the documentation accordingly.~~
- [x] I have read the **CONTRIBUTING** document.
~~- [ ] I have added tests to cover my changes if appropriate.~~
~~- [ ] All new and existing tests passed.~~
