### PR TITLE
Add admins parameter to Panorama push

### DIFF
--- a/panos/panorama.py
+++ b/panos/panorama.py
@@ -1148,6 +1148,10 @@ class PanoramaCommitAll(object):
             ET.SubElement(body, "name").text = self.name
             if self.description:
                 ET.SubElement(body, "description").text = self.description
+            if self.admins:
+                adms = ET.SubElement(body, "admin")
+                for user in self.admins:
+                    ET.SubElement(adms, "member").text = user
             if self.force_template_values:
                 ET.SubElement(body, "force-template-values").text = "yes"
             elif self.force_template_values is False:
@@ -1161,6 +1165,10 @@ class PanoramaCommitAll(object):
             ET.SubElement(body, "name").text = self.name
             if self.description:
                 ET.SubElement(body, "description").text = self.description
+            if self.admins:
+                adms = ET.SubElement(body, "admin")
+                for user in self.admins:
+                    ET.SubElement(adms, "member").text = user
             if self.force_template_values:
                 ET.SubElement(body, "force-template-values").text = "yes"
             elif self.force_template_values is False:

--- a/panos/panorama.py
+++ b/panos/panorama.py
@@ -1057,6 +1057,7 @@ class PanoramaCommitAll(object):
         name (str): The name of the location to push the config to (e.g. - name
             of the device group, name of the template, etc).
         description (str): The commit message.
+        admins (list): (PAN-OS 10.2+) List of admins whose changes are to be pushed.
         include_template (bool): (For `device group` style commits) Set to True to include
             template changes.
         force_template_values (bool): (For `device group`, `template`, or `template stack`
@@ -1077,6 +1078,7 @@ class PanoramaCommitAll(object):
         style,
         name,
         description=None,
+        admins=None,
         include_template=None,
         force_template_values=None,
         devices=None,
@@ -1092,10 +1094,13 @@ class PanoramaCommitAll(object):
             raise ValueError("Invalid style {0}".format(style))
         if devices and not isinstance(devices, list):
             raise ValueError("devices must be a list")
+        if admins and not isinstance(admins, list):
+            raise ValueError("admins must be a list")
 
         self.style = style
         self.name = name
         self.description = description
+        self.admins = admins
         self.include_template = include_template
         self.force_template_values = force_template_values
         self.devices = devices
@@ -1126,6 +1131,10 @@ class PanoramaCommitAll(object):
                     ET.SubElement(de, "entry", {"name": x})
             if self.description:
                 ET.SubElement(body, "description").text = self.description
+            if self.admins:
+                adms = ET.SubElement(body, "admin")
+                for user in self.admins:
+                    ET.SubElement(adms, "member").text = user
             if self.include_template:
                 ET.SubElement(body, "include-template").text = "yes"
             elif self.include_template is False:


### PR DESCRIPTION
## Description
Adding support for the [PAN-OS 10.2 feature](https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-release-notes/features-introduced-in-pan-os/panorama-features) of Administrator-Level Push from Panorama to Managed Devices

## Motivation and Context
Motivation is adding support for a new PAN-OS feature, and also to support adding this feature in pan-os-ansible ([ref](https://github.com/PaloAltoNetworks/pan-os-ansible/issues/361))

## How Has This Been Tested?
Tested locally, with Panorama 11.0.0 and managed firewall 10.2.3
```
    panorama = Panorama(HOSTNAME, USERNAME, PASSWORD)

    cmd = PanoramaCommitAll(
        style="device group",
        name="poc-dg",
        include_template=False,
        force_template_values=False,
        admins=["other"],
    )

    sync = False
    sync_all = True

    result = panorama.commit(cmd=cmd, sync=sync, sync_all=sync_all)
```

## Screenshots (if appropriate)
![Screenshot 2022-12-22 at 13 09 56](https://user-images.githubusercontent.com/6574404/209147785-c99714fd-fa78-4a83-a1a5-54addae69eec.png)

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
