### PR TITLE
docs: Remove dephell badge from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ the traditional interaction with the device via the GUI or CLI/API.
 
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org/)
-[![Powered by DepHell](https://img.shields.io/badge/Powered%20by-DepHell-red)](https://github.com/dephell/dephell)
 [![GitHub contributors](https://img.shields.io/github/contributors/PaloAltoNetworks/pan-os-python)](https://github.com/PaloAltoNetworks/pan-os-python/graphs/contributors/)
 
 -----


### PR DESCRIPTION
## Description
Remove the badge for "dephell" from the repo's Readme

## Motivation and Context
Dephell has been deprecated and it has just been removed it from the release workflow

## How Has This Been Tested?
N/A

## Screenshots (if appropriate)
![Screenshot_20230113-175230](https://user-images.githubusercontent.com/6574404/212630742-e529b328-8d41-4dac-87b0-32b4ac360f24.png)

## Types of changes
- Docs

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.