### PR TITLE
Handling Log Collector Group (LCG) pushes

### DIFF
--- a/panos/base.py
+++ b/panos/base.py
@@ -4862,21 +4862,24 @@ class PanDevice(PanObject):
             if exception:
                 raise err.PanCommitNotNeeded("Commit not needed", pan_device=self)
             else:
-                # By getting here, there was no "./result/job" in the commit response, 
+                # By getting here, there was no "./result/job" in the commit response,
                 # and there was no exception raised either, so capture the response message
                 commit_response_msg = commit_response.find("./msg/line").text
                 self._logger.debug("No job id. Msg: " + commit_response_msg)
 
                 # One scenario for arriving here in the the code is pushing to Log Collector Groups (LCG),
                 # they don't have a job ID, so test for the relevant message to see if this is the case
-                if 'Generated config and committed to connected collectors in group' in commit_response_msg:
+                if (
+                    "Generated config and committed to connected collectors in group"
+                    in commit_response_msg
+                ):
                     # With no real job ID to return, construct a reasonable response.
                     # There is currently no way to check the push to LCG was a success, so assume it was
                     log_collector_group_push_result = {
                         "success": True,
                         "result": "Ok",
                         "jobid": "0",
-                        "messages": [commit_response_msg]
+                        "messages": [commit_response_msg],
                     }
                     return log_collector_group_push_result
                 return

--- a/panos/base.py
+++ b/panos/base.py
@@ -4862,6 +4862,23 @@ class PanDevice(PanObject):
             if exception:
                 raise err.PanCommitNotNeeded("Commit not needed", pan_device=self)
             else:
+                # By getting here, there was no "./result/job" in the commit response, 
+                # and there was no exception raised either, so capture the response message
+                commit_response_msg = commit_response.find("./msg/line").text
+                self._logger.debug("No job id. Msg: " + commit_response_msg)
+
+                # One scenario for arriving here in the the code is pushing to Log Collector Groups (LCG),
+                # they don't have a job ID, so test for the relevant message to see if this is the case
+                if 'Generated config and committed to connected collectors in group' in commit_response_msg:
+                    # With no real job ID to return, construct a reasonable response.
+                    # There is currently no way to check the push to LCG was a success, so assume it was
+                    log_collector_group_push_result = {
+                        "success": True,
+                        "result": "Ok",
+                        "jobid": "0",
+                        "messages": [commit_response_msg]
+                    }
+                    return log_collector_group_push_result
                 return
         if not sync:
             # Don't synchronize, just return


### PR DESCRIPTION
## Description
Attempting to handle "push" to Log Collector Groups (LCG)

## Motivation and Context
Attempting to close #487 

XML API response from a push to a DG, for example, returns a job ID etc:
<response status="success" code="19">
    <result>
        <msg>
            <line>Job enqueued with jobid 16892</line>
        </msg>
        <job>16892</job>
    </result>
</response>

XML API response from a push to a LCG looks totally different:
<response status="success">
    <msg>
        <line>Generated config and committed to connected collectors in group log-coll-grp</line>
    </msg>
</response>

- There does not appear to be an ID against which to track the progress, status or success/failure of the push.
- The lack of `<result>` in the LCG response broke the Ansible module.
- The fixes proposed work, but may not be the best way to handle LCG pushes.

## How Has This Been Tested?
Tested locally. Both native Python scripts and Ansible playbooks now complete successfully.

Python script:
```
    panorama = Panorama(HOSTNAME, USERNAME, PASSWORD)

    cmd = PanoramaCommitAll(
        style="log collector group",
        name="log-coll-grp",
        include_template=False,
        force_template_values=False,
    )
    sync = True
    sync_all = True

    result = panorama.commit(cmd=cmd, sync=sync, sync_all=sync_all)
    
    print(result)
```
Result before:
```
None
```
Result after:
```
{'success': True, 'result': 'Ok', 'jobid': '0', 'messages': ['Generated config and committed to connected collectors in group log-coll-grp']}
```

Ansible playbook:
```
    - name: push log collector config
      paloaltonetworks.panos.panos_commit_push:
        provider: "{{ device }}"
        description: "push log collector config"
        style: "log collector group"
        name: "{{ log_collector_group }}"
```
Result before:
```
TASK [push log collector config] *********************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: 'NoneType' object is not subscriptable
fatal: [host_azurerama]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/Users/jholland/.ansible/tmp/ansible-tmp-1675702328.0676868-37346-62199662455005/AnsiballZ_panos_commit_push.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/Users/jholland/.ansible/tmp/ansible-tmp-1675702328.0676868-37346-62199662455005/AnsiballZ_panos_commit_push.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/Users/jholland/.ansible/tmp/ansible-tmp-1675702328.0676868-37346-62199662455005/AnsiballZ_panos_commit_push.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.paloaltonetworks.panos.plugins.modules.panos_commit_push', init_globals=dict(_module_fqn='ansible_collections.paloaltonetworks.panos.plugins.modules.panos_commit_push', _modlib_path=modlib_path),\n  File \"/Users/jholland/.pyenv/versions/3.10.4/lib/python3.10/runpy.py\", line 209, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/Users/jholland/.pyenv/versions/3.10.4/lib/python3.10/runpy.py\", line 96, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/Users/jholland/.pyenv/versions/3.10.4/lib/python3.10/runpy.py\", line 86, in _run_code\n    exec(code, run_globals)\n  File \"/var/folders/5k/v6w2wvm92sg_drdh0rw6p74w0000gp/T/ansible_paloaltonetworks.panos.panos_commit_push_payload_1b9iz2xk/ansible_paloaltonetworks.panos.panos_commit_push_payload.zip/ansible_collections/paloaltonetworks/panos/plugins/modules/panos_commit_push.py\", line 221, in <module>\n  File \"/var/folders/5k/v6w2wvm92sg_drdh0rw6p74w0000gp/T/ansible_paloaltonetworks.panos.panos_commit_push_payload_1b9iz2xk/ansible_paloaltonetworks.panos.panos_commit_push_payload.zip/ansible_collections/paloaltonetworks/panos/plugins/modules/panos_commit_push.py\", line 209, in main\nTypeError: 'NoneType' object is not subscriptable\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}

PLAY RECAP *******************************************************************************************
host_azurerama             : ok=1    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
```
Result after:
```
TASK [push log collector config] *********************************************************************
changed: [host_azurerama]

PLAY RECAP *******************************************************************************************
host_azurerama             : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.