### PR TITLE
fix: layer2 interface creation

### DIFF
--- a/panos/network.py
+++ b/panos/network.py
@@ -427,7 +427,7 @@ class Interface(VsysOperations):
 
         """
         # Don't add HA or aggregate-group interfaces to virtual router.
-        if getattr(self, "mode", "") in ("ha", "aggregate-group"):
+        if getattr(self, "mode", "") in ("ha", "aggregate-group", "layer2"):
             return False
 
         return self._set_reference(

--- a/panos/network.py
+++ b/panos/network.py
@@ -426,7 +426,7 @@ class Interface(VsysOperations):
             Zone: The zone for this interface after the operation completes
 
         """
-        # Don't add HA or aggregate-group interfaces to virtual router.
+        # Don't add HA, layer 2 or aggregate-group interfaces to virtual router.
         if getattr(self, "mode", "") in ("ha", "aggregate-group", "layer2"):
             return False
 


### PR DESCRIPTION
## Description
In PAN-OS, layer 2 interfaces do not get added to virtual routers. This fix stops the SDK trying to add layer 2 interfaces to virtual routers when the interface is created.

## Motivation and Context
Fix for https://github.com/PaloAltoNetworks/pan-os-ansible/issues/173

## How Has This Been Tested?
Tested locally via Ansible

Before:
```
TASK [Create interfaces] ***********************************************************************************************************************************************************************************************************************
failed: [host_labfw] (item={'name': 'ethernet1/8', 'mode': 'layer2', 'vlan_name': 'Management', 'lldp_enabled': False, 'zone_name': 'VLANs'}) => {"ansible_loop_var": "item", "changed": false, "item": {"lldp_enabled": false, "mode": "layer2", "name": "ethernet1/8", "vlan_name": "Management", "zone_name": "VLANs"}, "msg": "Failed set_virtual_router:  interface 'ethernet1/8' is not a valid reference"}
```

After:
```
TASK [Create interfaces] ***********************************************************************************************************************************************************************************************************************
changed: [host_labfw] => (item={'name': 'ethernet1/8', 'mode': 'layer2', 'vlan_name': 'Management', 'lldp_enabled': False, 'zone_name': 'VLANs'})
```

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.