### PR TITLE
feat: Fast failover for LACP on aggregate network interfaces

### DIFF
--- a/panos/network.py
+++ b/panos/network.py
@@ -1344,6 +1344,7 @@ class AggregateInterface(PhysicalInterface):
         lacp_passive_pre_negotiation (bool): Enable LACP passive pre-negotiation, off by default
         lacp_mode (str): Set LACP mode to 'active' or 'passive'
         lacp_rate (str): Set LACP transmission-rate to 'fast' or 'slow'
+        lacp_fast_failover (bool): Enable fast failover for LACP
 
     """
 
@@ -1509,6 +1510,14 @@ class AggregateInterface(PhysicalInterface):
                 condition={"mode": ["layer3", "layer2", "ha"], "lacp_enable": True},
                 values=["fast", "slow"],
                 path="{mode}/lacp/transmission-rate",
+            )
+        )
+        params.append(
+            VersionedParamPath(
+                "lacp_fast_failover",
+                condition={"mode": ["layer3", "layer2", "ha"], "lacp_enable": True},
+                vartype="yesno",
+                path="{mode}/lacp/fast-failover",
             )
         )
 


### PR DESCRIPTION
## Description
Adds the option to configure `fast failover` for LACP on aggregate network interfaces

## Motivation and Context
Adds the option to configure `fast failover` for LACP on aggregate network interfaces

## How Has This Been Tested?
Tested locally against PA-5220

## Screenshots (if appropriate)
Testing via Ansible playbook:
![Screenshot 2023-04-18 at 10 48 26](https://user-images.githubusercontent.com/6574404/232740287-46f5fe58-f5b5-4791-bd60-f2f50f51bb1e.png)
![Screenshot 2023-04-18 at 10 49 18](https://user-images.githubusercontent.com/6574404/232740311-bea7d417-8ff2-4cbc-a5a0-a30d4d0f6577.png)
![Screenshot 2023-04-18 at 10 49 45](https://user-images.githubusercontent.com/6574404/232740329-94bc3f88-053d-4807-967e-0a4b25d6c376.png)

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.