### PR TITLE
ci: Update Ubuntu runner version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
     name: Release
     if: github.event_name == 'push' && github.ref != 'refs/heads/develop'
     needs: [test, format]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
## Description
Update Ubuntu runner version for release process

## Motivation and Context
Needed because 18.04 is now unsupported (https://github.com/actions/runner-images/issues/6002 & https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources)

## How Has This Been Tested?
N/A

## Screenshots (if appropriate)
N/A

## Types of changes
- CI

## Checklist
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.