### PR TITLE
feat: Decrypt and GP for HTTP server profiles

### DIFF
--- a/panos/device.py
+++ b/panos/device.py
@@ -1494,6 +1494,12 @@ class HttpServerProfile(VersionedPanObject):
         iptag_name (str): (PAN-OS 9.0+) Name for custom IP tag format
         iptag_uri_format (str): (PAN-OS 9.0+) URI format for custom IP tag format
         iptag_payload (str): (PAN-OS 9.0+) Payload for custom IP tag format
+        globalprotect_name (str): (PAN-OS 9.1+) Name for custom GlobalProtect format
+        globalprotect_uri_format (str): (PAN-OS 9.1+) URI format for custom GlobalProtect format
+        globalprotect_payload (str): (PAN-OS 9.1+) Payload for custom GlobalProtect format
+        decryption_name (str): (PAN-OS 10.0+) Name for custom Decryption format
+        decryption_uri_format (str): (PAN-OS 10.0+) URI format for custom Decryption format
+        decryption_payload (str): (PAN-OS 10.0+) Payload for custom Decryption format
 
     """
 
@@ -1529,6 +1535,10 @@ class HttpServerProfile(VersionedPanObject):
         "device.HttpSctpParam",
         "device.HttpIpTagHeader",
         "device.HttpIpTagParam",
+        "device.HttpGlobalProtectHeader",
+        "device.HttpGlobalProtectParam",
+        "device.HttpDecryptionHeader",
+        "device.HttpDecryptionParam",
     )
 
     def _setup(self):
@@ -1635,6 +1645,18 @@ class HttpServerProfile(VersionedPanObject):
         params[-1].add_profile("9.0.0", path="format/iptag/url-format")
         params.append(VersionedParamPath("iptag_payload", exclude=True))
         params[-1].add_profile("9.0.0", path="format/iptag/payload")
+        params.append(VersionedParamPath("globalprotect_name", exclude=True))
+        params[-1].add_profile("9.1.0", path="format/globalprotect/name")
+        params.append(VersionedParamPath("globalprotect_uri_format", exclude=True))
+        params[-1].add_profile("9.1.0", path="format/globalprotect/url-format")
+        params.append(VersionedParamPath("globalprotect_payload", exclude=True))
+        params[-1].add_profile("9.1.0", path="format/globalprotect/payload")
+        params.append(VersionedParamPath("decryption_name", exclude=True))
+        params[-1].add_profile("10.0.0", path="format/decryption/name")
+        params.append(VersionedParamPath("decryption_uri_format", exclude=True))
+        params[-1].add_profile("10.0.0", path="format/decryption/url-format")
+        params.append(VersionedParamPath("decryption_payload", exclude=True))
+        params[-1].add_profile("10.0.0", path="format/decryption/payload")
 
         self._params = tuple(params)
 
@@ -2110,6 +2132,66 @@ class HttpIpTagParam(ValueEntry):
     """
 
     LOCATION = "/format/iptag/params"
+    ROOT = Root.PANORAMA_VSYS
+
+
+class HttpDecryptionHeader(ValueEntry):
+    """HTTP header for Decryption.
+
+    Note: This is valid for PAN-OS 10.0+
+
+    Args:
+        name (str): The header name
+        value (str): The header value
+
+    """
+
+    LOCATION = "/format/decryption/headers"
+    ROOT = Root.PANORAMA_VSYS
+
+
+class HttpDecryptionParam(ValueEntry):
+    """HTTP param for Decryption.
+
+    Note: This is valid for PAN-OS 10.0+
+
+    Args:
+        name (str): The param name
+        value (str): The param value
+
+    """
+
+    LOCATION = "/format/decryption/params"
+    ROOT = Root.PANORAMA_VSYS
+
+
+class HttpGlobalProtectHeader(ValueEntry):
+    """HTTP header for GlobalProtect.
+
+    Note: This is valid for PAN-OS 9.1+
+
+    Args:
+        name (str): The header name
+        value (str): The header value
+
+    """
+
+    LOCATION = "/format/globalprotect/headers"
+    ROOT = Root.PANORAMA_VSYS
+
+
+class HttpGlobalProtectParam(ValueEntry):
+    """HTTP param for GlobalProtect.
+
+    Note: This is valid for PAN-OS 9.1+
+
+    Args:
+        name (str): The param name
+        value (str): The param value
+
+    """
+
+    LOCATION = "/format/globalprotect/params"
     ROOT = Root.PANORAMA_VSYS
 
 


### PR DESCRIPTION
## Description
Add the option for HTTP Server Profiles to key off Decrypt and GP logs.

## Motivation and Context
Decrypt and GP logs were added in PAN-OS 10.0 and 9.1 respectively.
This feature coverage is also useful for upcoming Event-Driven Ansible operations.

## How Has This Been Tested?
Tested locally with Ansible ([playbook](https://github.com/jamesholland-uk/playground/blob/main/pan-os-ansible/http-server-profiles.yml))

## Screenshots (if appropriate)
![Screenshot 2023-04-26 at 14 54 11](https://user-images.githubusercontent.com/6574404/234622078-db6456f5-8e8d-45e5-8775-c3817708ca18.png)
![Screenshot 2023-04-26 at 14 51 38](https://user-images.githubusercontent.com/6574404/234622157-329a93b5-2c6c-4615-a265-0e5c0b0e4c9a.png)
![Screenshot 2023-04-26 at 14 50 45](https://user-images.githubusercontent.com/6574404/234622180-689eae2f-9a77-4b61-aea8-568bfd92d4ff.png)
![Screenshot 2023-04-26 at 14 51 01](https://user-images.githubusercontent.com/6574404/234622202-8f105919-68c9-4f95-9b5d-0ff88dacdfb4.png)

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.