### PR TITLE
incorrect path name fix

### DIFF
--- a/panos/device.py
+++ b/panos/device.py
@@ -757,7 +757,7 @@ class AuthenticationProfile(VersionedPanObject):
         )
         params.append(
             VersionedParamPath(
-                "failed_attempts", vartype="int", path="locakout/failed-attempts"
+                "failed_attempts", vartype="int", path="lockout/failed-attempts"
             )
         )
         params.append(
@@ -1290,7 +1290,11 @@ class LdapServerProfile(VersionedPanObject):
             )
         )
         params.append(
-            VersionedParamPath("disabled", vartype="yesno", path="disabled",),
+            VersionedParamPath(
+                "disabled",
+                vartype="yesno",
+                path="disabled",
+            ),
         )
 
         self._params = tuple(params)
@@ -1436,7 +1440,10 @@ class SyslogServer(VersionedPanObject):
                 "facility",
                 default="LOG_USER",
                 path="facility",
-                values=["LOG_USER",] + ["LOG_LOCAL{0}".format(x) for x in range(8)],
+                values=[
+                    "LOG_USER",
+                ]
+                + ["LOG_LOCAL{0}".format(x) for x in range(8)],
             )
         )
 
@@ -2244,12 +2251,28 @@ class CertificateProfile(VersionedPanObject):
         )
         params.append(
             VersionedParamPath(
-                "username_field_value", path="username-field/{username_field}",
+                "username_field_value",
+                path="username-field/{username_field}",
             )
         )
-        params.append(VersionedParamPath("domain", path="domain",))
-        params.append(VersionedParamPath("use_crl", path="use-crl",))
-        params.append(VersionedParamPath("use_ocsp", path="use-ocsp",))
+        params.append(
+            VersionedParamPath(
+                "domain",
+                path="domain",
+            )
+        )
+        params.append(
+            VersionedParamPath(
+                "use_crl",
+                path="use-crl",
+            )
+        )
+        params.append(
+            VersionedParamPath(
+                "use_ocsp",
+                path="use-ocsp",
+            )
+        )
         params.append(
             VersionedParamPath(
                 "crl_receive_timeout",
@@ -2276,27 +2299,50 @@ class CertificateProfile(VersionedPanObject):
         )
         params.append(
             VersionedParamPath(
-                "block_unknown_certificate", vartype="yesno", path="block-unknown-cert",
+                "block_unknown_certificate",
+                vartype="yesno",
+                path="block-unknown-cert",
             )
         )
         params.append(
             VersionedParamPath(
-                "block_certificate_timeout", vartype="yesno", path="block-timeout-cert",
+                "block_certificate_timeout",
+                vartype="yesno",
+                path="block-timeout-cert",
             )
         )
         params.append(
-            VersionedParamPath("block_unauthenticated_certificate", exclude=True,)
+            VersionedParamPath(
+                "block_unauthenticated_certificate",
+                exclude=True,
+            )
         )
         params[-1].add_profile(
-            "7.1.0", vartype="yesno", path="block-unauthenticated-cert",
+            "7.1.0",
+            vartype="yesno",
+            path="block-unauthenticated-cert",
         )
-        params.append(VersionedParamPath("block_expired_certificate", exclude=True,))
-        params[-1].add_profile(
-            "8.1.0", vartype="yesno", path="block-expired-cert",
+        params.append(
+            VersionedParamPath(
+                "block_expired_certificate",
+                exclude=True,
+            )
         )
-        params.append(VersionedParamPath("ocsp_exclude_nonce", exclude=True,))
         params[-1].add_profile(
-            "9.0.0", path="ocsp-exclude-nonce", vartype="yesno",
+            "8.1.0",
+            vartype="yesno",
+            path="block-expired-cert",
+        )
+        params.append(
+            VersionedParamPath(
+                "ocsp_exclude_nonce",
+                exclude=True,
+            )
+        )
+        params[-1].add_profile(
+            "9.0.0",
+            path="ocsp-exclude-nonce",
+            vartype="yesno",
         )
 
         self._params = tuple(params)
@@ -2323,13 +2369,27 @@ class CertificateProfileCaCertificate(VersionedPanObject):
         # params
         params = []
 
-        params.append(VersionedParamPath("default_ocsp_url", path="default-ocsp-url",))
         params.append(
-            VersionedParamPath("ocsp_verify_certificate", path="ocsp-verify-cert",)
+            VersionedParamPath(
+                "default_ocsp_url",
+                path="default-ocsp-url",
+            )
         )
-        params.append(VersionedParamPath("template_name", exclude=True,))
+        params.append(
+            VersionedParamPath(
+                "ocsp_verify_certificate",
+                path="ocsp-verify-cert",
+            )
+        )
+        params.append(
+            VersionedParamPath(
+                "template_name",
+                exclude=True,
+            )
+        )
         params[-1].add_profile(
-            "9.0.0", path="template-name",
+            "9.0.0",
+            path="template-name",
         )
 
         self._params = tuple(params)
@@ -2364,7 +2424,8 @@ class SslDecrypt(VersionedPanObject):
 
         params.append(
             VersionedParamPath(
-                "forward_trust_certificate_rsa", path="forward-trust-certificate/rsa",
+                "forward_trust_certificate_rsa",
+                path="forward-trust-certificate/rsa",
             )
         )
         params.append(
@@ -2387,13 +2448,17 @@ class SslDecrypt(VersionedPanObject):
         )
         params.append(
             VersionedParamPath(
-                "root_ca_excludes", vartype="member", path="root-ca-exclude-list",
+                "root_ca_excludes",
+                vartype="member",
+                path="root-ca-exclude-list",
             )
         )
         # Only option present on Panorama.
         params.append(
             VersionedParamPath(
-                "trusted_root_cas", vartype="member", path="trusted-root-CA",
+                "trusted_root_cas",
+                vartype="member",
+                path="trusted-root-CA",
             )
         )
         params.append(
@@ -2428,8 +2493,19 @@ class SslDecryptExcludeCert(VersionedPanObject):
         # params
         params = []
 
-        params.append(VersionedParamPath("description", path="description",))
-        params.append(VersionedParamPath("exclude", vartype="yesno", path="exclude",))
+        params.append(
+            VersionedParamPath(
+                "description",
+                path="description",
+            )
+        )
+        params.append(
+            VersionedParamPath(
+                "exclude",
+                vartype="yesno",
+                path="exclude",
+            )
+        )
 
         self._params = tuple(params)
 
@@ -2459,9 +2535,19 @@ class LocalUserDatabaseUser(VersionedPanObject):
         params = []
 
         params.append(
-            VersionedParamPath("password_hash", vartype="encrypted", path="phash",)
+            VersionedParamPath(
+                "password_hash",
+                vartype="encrypted",
+                path="phash",
+            )
         )
-        params.append(VersionedParamPath("disabled", vartype="yesno", path="disabled",))
+        params.append(
+            VersionedParamPath(
+                "disabled",
+                vartype="yesno",
+                path="disabled",
+            )
+        )
 
         self._params = tuple(params)
 
@@ -2502,6 +2588,12 @@ class LocalUserDatabaseGroup(VersionedPanObject):
         # params
         params = []
 
-        params.append(VersionedParamPath("users", vartype="member", path="user",))
+        params.append(
+            VersionedParamPath(
+                "users",
+                vartype="member",
+                path="user",
+            )
+        )
 
         self._params = tuple(params)

--- a/panos/device.py
+++ b/panos/device.py
@@ -1290,11 +1290,7 @@ class LdapServerProfile(VersionedPanObject):
             )
         )
         params.append(
-            VersionedParamPath(
-                "disabled",
-                vartype="yesno",
-                path="disabled",
-            ),
+            VersionedParamPath("disabled", vartype="yesno", path="disabled",),
         )
 
         self._params = tuple(params)
@@ -1440,10 +1436,7 @@ class SyslogServer(VersionedPanObject):
                 "facility",
                 default="LOG_USER",
                 path="facility",
-                values=[
-                    "LOG_USER",
-                ]
-                + ["LOG_LOCAL{0}".format(x) for x in range(8)],
+                values=["LOG_USER",] + ["LOG_LOCAL{0}".format(x) for x in range(8)],
             )
         )
 
@@ -2251,28 +2244,12 @@ class CertificateProfile(VersionedPanObject):
         )
         params.append(
             VersionedParamPath(
-                "username_field_value",
-                path="username-field/{username_field}",
+                "username_field_value", path="username-field/{username_field}",
             )
         )
-        params.append(
-            VersionedParamPath(
-                "domain",
-                path="domain",
-            )
-        )
-        params.append(
-            VersionedParamPath(
-                "use_crl",
-                path="use-crl",
-            )
-        )
-        params.append(
-            VersionedParamPath(
-                "use_ocsp",
-                path="use-ocsp",
-            )
-        )
+        params.append(VersionedParamPath("domain", path="domain",))
+        params.append(VersionedParamPath("use_crl", path="use-crl",))
+        params.append(VersionedParamPath("use_ocsp", path="use-ocsp",))
         params.append(
             VersionedParamPath(
                 "crl_receive_timeout",
@@ -2299,50 +2276,27 @@ class CertificateProfile(VersionedPanObject):
         )
         params.append(
             VersionedParamPath(
-                "block_unknown_certificate",
-                vartype="yesno",
-                path="block-unknown-cert",
+                "block_unknown_certificate", vartype="yesno", path="block-unknown-cert",
             )
         )
         params.append(
             VersionedParamPath(
-                "block_certificate_timeout",
-                vartype="yesno",
-                path="block-timeout-cert",
+                "block_certificate_timeout", vartype="yesno", path="block-timeout-cert",
             )
         )
         params.append(
-            VersionedParamPath(
-                "block_unauthenticated_certificate",
-                exclude=True,
-            )
+            VersionedParamPath("block_unauthenticated_certificate", exclude=True,)
         )
         params[-1].add_profile(
-            "7.1.0",
-            vartype="yesno",
-            path="block-unauthenticated-cert",
+            "7.1.0", vartype="yesno", path="block-unauthenticated-cert",
         )
-        params.append(
-            VersionedParamPath(
-                "block_expired_certificate",
-                exclude=True,
-            )
-        )
+        params.append(VersionedParamPath("block_expired_certificate", exclude=True,))
         params[-1].add_profile(
-            "8.1.0",
-            vartype="yesno",
-            path="block-expired-cert",
+            "8.1.0", vartype="yesno", path="block-expired-cert",
         )
-        params.append(
-            VersionedParamPath(
-                "ocsp_exclude_nonce",
-                exclude=True,
-            )
-        )
+        params.append(VersionedParamPath("ocsp_exclude_nonce", exclude=True,))
         params[-1].add_profile(
-            "9.0.0",
-            path="ocsp-exclude-nonce",
-            vartype="yesno",
+            "9.0.0", path="ocsp-exclude-nonce", vartype="yesno",
         )
 
         self._params = tuple(params)
@@ -2369,27 +2323,13 @@ class CertificateProfileCaCertificate(VersionedPanObject):
         # params
         params = []
 
+        params.append(VersionedParamPath("default_ocsp_url", path="default-ocsp-url",))
         params.append(
-            VersionedParamPath(
-                "default_ocsp_url",
-                path="default-ocsp-url",
-            )
+            VersionedParamPath("ocsp_verify_certificate", path="ocsp-verify-cert",)
         )
-        params.append(
-            VersionedParamPath(
-                "ocsp_verify_certificate",
-                path="ocsp-verify-cert",
-            )
-        )
-        params.append(
-            VersionedParamPath(
-                "template_name",
-                exclude=True,
-            )
-        )
+        params.append(VersionedParamPath("template_name", exclude=True,))
         params[-1].add_profile(
-            "9.0.0",
-            path="template-name",
+            "9.0.0", path="template-name",
         )
 
         self._params = tuple(params)
@@ -2424,8 +2364,7 @@ class SslDecrypt(VersionedPanObject):
 
         params.append(
             VersionedParamPath(
-                "forward_trust_certificate_rsa",
-                path="forward-trust-certificate/rsa",
+                "forward_trust_certificate_rsa", path="forward-trust-certificate/rsa",
             )
         )
         params.append(
@@ -2448,17 +2387,13 @@ class SslDecrypt(VersionedPanObject):
         )
         params.append(
             VersionedParamPath(
-                "root_ca_excludes",
-                vartype="member",
-                path="root-ca-exclude-list",
+                "root_ca_excludes", vartype="member", path="root-ca-exclude-list",
             )
         )
         # Only option present on Panorama.
         params.append(
             VersionedParamPath(
-                "trusted_root_cas",
-                vartype="member",
-                path="trusted-root-CA",
+                "trusted_root_cas", vartype="member", path="trusted-root-CA",
             )
         )
         params.append(
@@ -2493,19 +2428,8 @@ class SslDecryptExcludeCert(VersionedPanObject):
         # params
         params = []
 
-        params.append(
-            VersionedParamPath(
-                "description",
-                path="description",
-            )
-        )
-        params.append(
-            VersionedParamPath(
-                "exclude",
-                vartype="yesno",
-                path="exclude",
-            )
-        )
+        params.append(VersionedParamPath("description", path="description",))
+        params.append(VersionedParamPath("exclude", vartype="yesno", path="exclude",))
 
         self._params = tuple(params)
 
@@ -2535,19 +2459,9 @@ class LocalUserDatabaseUser(VersionedPanObject):
         params = []
 
         params.append(
-            VersionedParamPath(
-                "password_hash",
-                vartype="encrypted",
-                path="phash",
-            )
+            VersionedParamPath("password_hash", vartype="encrypted", path="phash",)
         )
-        params.append(
-            VersionedParamPath(
-                "disabled",
-                vartype="yesno",
-                path="disabled",
-            )
-        )
+        params.append(VersionedParamPath("disabled", vartype="yesno", path="disabled",))
 
         self._params = tuple(params)
 
@@ -2588,12 +2502,6 @@ class LocalUserDatabaseGroup(VersionedPanObject):
         # params
         params = []
 
-        params.append(
-            VersionedParamPath(
-                "users",
-                vartype="member",
-                path="user",
-            )
-        )
+        params.append(VersionedParamPath("users", vartype="member", path="user",))
 
         self._params = tuple(params)


### PR DESCRIPTION
This simple misspelling causes the creation of AuthenticationProfile objects to fail

```
PanXapiError:  authentication-profile -> MyRADIUS -> locakout unexpected here
````

