### PR TITLE
Fix action_community_argument vartype

### DIFF
--- a/panos/network.py
+++ b/panos/network.py
@@ -3515,11 +3515,12 @@ class BgpPolicyRule(BgpPolicyFilter):
             * overwrite
         action_community_argument (str): Argument to the action community value if needed
             * None
+            * regex
+        action_community_modifier (str): Argument to the action community value when type is 'append' or 'overwrite'
             * local-as
             * no-advertise
             * no-export
             * nopeer
-            * regex
             * 32-bit value
             * AS:VAL
         action_extended_community_type (str): Extended community update options

--- a/panos/network.py
+++ b/panos/network.py
@@ -3814,11 +3814,12 @@ class BgpPolicyExportRule(BgpPolicyRule):
             * overwrite
         action_community_argument (str): Argument to the action community value if needed
             * None
+            * regex
+        action_community_modifier (str): Argument to the action community value when type is 'append' or 'overwrite'
             * local-as
             * no-advertise
             * no-export
             * nopeer
-            * regex
             * 32-bit value
             * AS:VAL
         action_extended_community_type (str): Extended community update options

--- a/panos/network.py
+++ b/panos/network.py
@@ -3628,6 +3628,7 @@ class BgpPolicyRule(BgpPolicyFilter):
                     "action_community_type": ["remove-regex", "append", "overwrite"],
                 },
                 path="action/{action}/update/community/{action_community_type}",
+                vartype="member"
             )
         )
         params.append(

--- a/panos/network.py
+++ b/panos/network.py
@@ -3640,7 +3640,7 @@ class BgpPolicyRule(BgpPolicyFilter):
                     "action_community_type": ["append", "overwrite"],
                 },
                 path="action/{action}/update/community/{action_community_type}",
-                vartype="member"
+                vartype="member",
             )
         )
         params.append(

--- a/panos/network.py
+++ b/panos/network.py
@@ -3625,7 +3625,18 @@ class BgpPolicyRule(BgpPolicyFilter):
                 default=None,
                 condition={
                     "action": "allow",
-                    "action_community_type": ["remove-regex", "append", "overwrite"],
+                    "action_community_type": ["remove-regex"],
+                },
+                path="action/{action}/update/community/{action_community_type}",
+            )
+        )
+        params.append(
+            VersionedParamPath(
+                "action_community_modifier",
+                default=None,
+                condition={
+                    "action": "allow",
+                    "action_community_type": ["append", "overwrite"],
                 },
                 path="action/{action}/update/community/{action_community_type}",
                 vartype="member"

--- a/panos/network.py
+++ b/panos/network.py
@@ -3718,11 +3718,12 @@ class BgpPolicyImportRule(BgpPolicyRule):
             * overwrite
         action_community_argument (str): Argument to the action community value if needed
             * None
+            * regex
+        action_community_modifier (str): Argument to the action community value when type is 'append' or 'overwrite'
             * local-as
             * no-advertise
             * no-export
             * nopeer
-            * regex
             * 32-bit value
             * AS:VAL
         action_extended_community_type (str): Extended community update options


### PR DESCRIPTION
## Description

Fixes #534 

In at least as early as 9.1, the 'append community' action within BGP is a member list which was causing BGP updates to fail when attempting to update an existing BGP protocol element with this configured.

All that has changed is the vartype of "action_community_argument" to be "member". 

Example XML from 9.1 for this path;

```xml
<response status="success" code="19">
    <result total-count="1" count="1">
        <append admin="panadmin" dirtyId="12" time="2023/11/21 11:36:45">
            <member admin="panadmin" dirtyId="12" time="2023/11/21 11:36:45">local-as</member>
        </append>
    </result>
</response>
```

