### PR TITLE
Add additional resources to show_system_resources

### DIFF
--- a/panos/firewall.py
+++ b/panos/firewall.py
@@ -423,24 +423,27 @@ class Firewall(PanDevice):
         result = self.xapi.xml_root()
         if self._version_info >= (9, 0, 0):
             regex = re.compile(
-                r"load average: ([\d\.]+).*? ([\d\.]+) id,.*KiB Mem :\s+(\d+) total,.*? (\d+) free",
+                r"load average: ([\d\.]+).*? ([\d\.]+) id,.*KiB Mem :"
+                r"\s+(\d+) total,.*? (\d+) free.*? (\d+) used,"
+                r".*? (\d+) buff/cache",
                 re.DOTALL,
             )
         else:
             regex = re.compile(
-                r"load average: ([\d.]+).* ([\d.]+)%id.*Mem:.*?([\d.]+)k total.*?([\d]+)k free",
+                r"load average: ([\d.]+).* ([\d.]+)%id.*"
+                r"Mem:.*?([\d.]+)k total.*?"
+                r"([\d]+)k free.*?([\d]+)k used.*?([\d]+)k buff/cache",
                 re.DOTALL,
             )
         match = regex.search(result)
         if match:
-            """
-            return cpu, mem_free, load
-            """
             return {
                 "load": Decimal(match.group(1)),
                 "cpu": 100 - Decimal(match.group(2)),
                 "mem_total": int(match.group(3)),
                 "mem_free": int(match.group(4)),
+                "mem_used": int(match.group(5)),
+                "mem_buffer": int(match.group(6))
             }
         else:
             raise err.PanDeviceError(


### PR DESCRIPTION
## Description

Added additional system resources to the output when calling the method show_system_resources per the enhancement issue linked below.

## Motivation and Context

Issue: https://github.com/PaloAltoNetworks/pan-os-python/issues/478

## How Has This Been Tested?

I have a lab environment running Panorama and Palo Alto VM Series endpoints.
To test the changes I made the update to my venv with the new block of code and updated regex. I ran the method and printed the return value. This included the mem_used and buffer memory used values I was expecting. Verified this by connecting to the Panorama endpoint and running a show system resources command.

## Screenshots (if appropriate)

<img width="564" alt="image" src="https://github.com/PaloAltoNetworks/pan-os-python/assets/41241700/7446da6e-28b0-484f-a4a8-c8ec7a4e8b3a">

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes if appropriate.
- [X] All new and existing tests passed.
