### PR TITLE
docs: Fix return value descriptions for set_virtual_router methods

### DIFF
--- a/panos/network.py
+++ b/panos/network.py
@@ -449,7 +449,7 @@ class Interface(VsysOperations):
                 was updated (update=True).
 
         Returns:
-            Zone: The zone for this interface after the operation completes
+            VirtualRouter: The virtual router for this interface after the operation completes
 
         """
         # Don't add HA, layer 2 or aggregate-group interfaces to virtual router.
@@ -811,7 +811,7 @@ class AbstractSubinterface(object):
                 (Default: False)
 
         Returns:
-            Zone: The zone for this interface after the operation completes
+            VirtualRouter: The virtual router for this interface after the operation completes
 
         """
         interface = Layer3Subinterface(self.name, self.tag)


### PR DESCRIPTION
## Description

Fix return value descriptions for `set_virtual_router` methods of `Interface` and `AbstractSubinterface` classes.

## Motivation and Context

Documentation fix.

## How Has This Been Tested?

n/a

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
