### PR TITLE
fix(panos/base): Added check for `commit_response` text validation

### DIFF
--- a/panos/base.py
+++ b/panos/base.py
@@ -4900,7 +4900,7 @@ class PanDevice(PanObject):
         except AttributeError:
             if exception:
                 raise err.PanCommitNotNeeded("Commit not needed", pan_device=self)
-            else:
+            elif commit_response.find("./msg/line") is not None:
                 # By getting here, there was no "./result/job" in the commit response,
                 # and there was no exception raised either, so capture the response message
                 commit_response_msg = commit_response.find("./msg/line").text
@@ -4921,6 +4921,7 @@ class PanDevice(PanObject):
                         "messages": [commit_response_msg],
                     }
                     return log_collector_group_push_result
+            else:
                 return
         if not sync:
             # Don't synchronize, just return


### PR DESCRIPTION
## Description

With latest develop/master branch commit (not yet released) - there was an issue committing to Panorama which has no changes to commit (discovered when running the `panos_commit_panorama` ansible module).

## Motivation and Context

Simple python script to test the issue:

from panos.panorama import Panorama, PanoramaCommitAll, PanoramaCommit
```python
panorama = Panorama("<YOUR_IP>", "<YOUR_USERNAME>", "<YOUR_PASSWORD>")

cmd = PanoramaCommit()
sync = True

result = panorama.commit(cmd=cmd, sync=sync)

print(result)
```

Result:

```bash
python3 python_test_panorama.py
Traceback (most recent call last):
  File "/Users/hgunica/Documents/PROJECTS/kyndryl/pso-azure-kyndryl-1089022/kx-panw-cac/ansible/panorama-cac/.venv/lib/python3.11/site-packages/panos/base.py", line 4899, in _commit
    jobid = commit_response.find("./result/job").text
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'text'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/hgunica/Documents/PROJECTS/kyndryl/pso-azure-kyndryl-1089022/kx-panw-cac/ansible/panorama-cac/python_test_panorama.py", line 17, in <module>
    result = panorama.commit(cmd=cmd, sync=sync)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hgunica/Documents/PROJECTS/kyndryl/pso-azure-kyndryl-1089022/kx-panw-cac/ansible/panorama-cac/.venv/lib/python3.11/site-packages/panos/base.py", line 4803, in commit
    return self._commit(
           ^^^^^^^^^^^^^
  File "/Users/hgunica/Documents/PROJECTS/kyndryl/pso-azure-kyndryl-1089022/kx-panw-cac/ansible/panorama-cac/.venv/lib/python3.11/site-packages/panos/base.py", line 4906, in _commit
    commit_response_msg = commit_response.find("./msg/line").text
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'text'
```
## How Has This Been Tested?

Tested with above mentioned script. After validation was added:

```bash
python3 python_test_panorama.py
None
```

Ansible task also passes:

```bash
TASK [bootstrap_panorama : Commit to Panorama] *************************************************************************************************
ok: [panorama-mgmt-secondary]
```

Test with an actual commit is still working properly:

```bash
python3 python_test_panorama.py
{'success': True, 'result': 'OK', 'jobid': '24', 'user': 'panadmin', 'warnings': {'line': 'The latest API KeyGen was executed on Sat Mar 23 08:31:58 2024 with the deprecated algorithm. You are advised to configure the more secure API key infrastructure by web interface: Setup -> Management -> Authentiation Settings -> API Key Certificate, or by CLI: set deviceconfig setting management api key certificate\n'}, 'starttime': '2024/03/23 08:31:59', 'endtime': '2024/03/23 08:32:17', 'messages': ['Configuration committed successfully', 'Local configuration size: 9 KB', 'Predefined configuration size: 16 MB', 'Total configuration size(local, predefined): 17 MB', 'Maximum recommended configuration size: 120 MB (14% configured)'], 'devices': {}, 'xml': <Element 'response' at 0x10251ffb0>}
```

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
