### PR TITLE
Fix HA Peer Serial location

### DIFF
--- a/panos/firewall.py
+++ b/panos/firewall.py
@@ -383,7 +383,7 @@ class Firewall(PanDevice):
             Var("multi-vsys", vartype="bool"),
             Var("vsys_id", "vsys", default="vsys1"),
             Var("vsys_name"),
-            Var("ha/state/peer/serial", "serial_ha_peer"),
+            Var("ha/peer/serial", "serial_ha_peer"),
         )
         if len(xml[0]) > 1:
             # This is a 'show devices' op command


### PR DESCRIPTION

## Motivation and Context

During testing and attempts to create HA pairs during initialization of a device tree from Panorama, I noticed that I was unable to get the HA peer serial, and after some investigation I found that this path was incorrect from the XML I was able to test against.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

This has been run against an environment with several Panorama and Firewall devices on PAN-OS 10.2.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
