### PR TITLE
add members to automodule for Sphinx to pickup docstrings

### DIFF
--- a/docs/module-base.rst
+++ b/docs/module-base.rst
@@ -11,3 +11,5 @@ Class Reference
 ---------------
 
 .. automodule:: panos.base
+   :members: PanObject
+   :no-index:

--- a/docs/module-device.rst
+++ b/docs/module-device.rst
@@ -16,3 +16,4 @@ Class Reference
 ---------------
 
 .. automodule:: panos.device
+   :members:

--- a/docs/module-errors.rst
+++ b/docs/module-errors.rst
@@ -11,3 +11,4 @@ Class Reference
 ---------------
 
 .. automodule:: panos.errors
+   :members:

--- a/docs/module-firewall.rst
+++ b/docs/module-firewall.rst
@@ -16,3 +16,4 @@ Class Reference
 ---------------
 
 .. automodule:: panos.firewall
+   :members:

--- a/docs/module-ha.rst
+++ b/docs/module-ha.rst
@@ -16,3 +16,4 @@ Class Reference
 ---------------
 
 .. automodule:: panos.ha
+   :members:

--- a/docs/module-network.rst
+++ b/docs/module-network.rst
@@ -16,3 +16,4 @@ Class Reference
 ---------------
 
 .. automodule:: panos.network
+   :members:

--- a/docs/module-objects.rst
+++ b/docs/module-objects.rst
@@ -11,3 +11,4 @@ Class Reference
 ---------------
 
 .. automodule:: panos.objects
+   :members:

--- a/docs/module-panorama.rst
+++ b/docs/module-panorama.rst
@@ -16,3 +16,4 @@ Class Reference
 ---------------
 
 .. automodule:: panos.panorama
+   :members:

--- a/docs/module-plugins.rst
+++ b/docs/module-plugins.rst
@@ -16,3 +16,4 @@ Class Reference
 ---------------
 
 .. automodule:: panos.plugins
+   :members:

--- a/docs/module-policies.rst
+++ b/docs/module-policies.rst
@@ -16,3 +16,4 @@ Class Reference
 ---------------
 
 .. automodule:: panos.policies
+   :members:

--- a/docs/module-predefined.rst
+++ b/docs/module-predefined.rst
@@ -11,3 +11,4 @@ Class Reference
 ---------------
 
 .. automodule:: panos.predefined
+   :members:

--- a/docs/module-updater.rst
+++ b/docs/module-updater.rst
@@ -11,3 +11,4 @@ Class Reference
 ---------------
 
 .. automodule:: panos.updater
+   :members:

--- a/docs/module-userid.rst
+++ b/docs/module-userid.rst
@@ -11,3 +11,4 @@ Class Reference
 ---------------
 
 .. automodule:: panos.userid
+   :members:


### PR DESCRIPTION
## Description

Added ":members:" to module-*.rst files.

## Motivation and Context

The current documentation is missing the docstrings from the classes in the modules, it shows only the docstring from the module itself which is not useful for the module users.

## How Has This Been Tested?

I run "make docs" for Sphinx to crate the docs and verified that the docstrings are now populated.

## Screenshots (if appropriate)

This is what the current documentation shows:
<img width="581" alt="class-reference-current" src="https://github.com/user-attachments/assets/f518a18c-51e7-453a-93b9-834a87f1ebc6">

This is what it will show with the changes:
<img width="750" alt="class-reference-change" src="https://github.com/user-attachments/assets/1eb6e04a-de91-4e24-ab45-7060ca64d127">

## Types of changes

<!--- What types of changes does your code introduce? -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
