### PR TITLE
feat(network.StaticRoute): conditions and none value nexthop_type

### DIFF
--- a/panos/network.py
+++ b/panos/network.py
@@ -1834,11 +1834,18 @@ class StaticRoute(VersionedPanObject):
             VersionedParamPath(
                 "nexthop_type",
                 default="ip-address",
-                values=["discard", "ip-address", "next-vr"],
+                values=["discard", "ip-address", "next-vr", "none"],
                 path="nexthop/{nexthop_type}",
+                condition={"nexthop_type": ["discard", "ip-address", "next-vr"]},
             )
         )
-        params.append(VersionedParamPath("nexthop", path="nexthop/{nexthop_type}"))
+        params.append(
+            VersionedParamPath(
+                "nexthop",
+                path="nexthop/{nexthop_type}",
+                condition={"nexthop_type": ["ip-address", "next-vr"]},
+            )
+        )
         params.append(VersionedParamPath("interface", path="interface"))
         params.append(
             VersionedParamPath("admin_dist", vartype="int", path="admin-dist")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -260,6 +260,56 @@ class TestElementStr_7_0(unittest.TestCase):
 
         self.assertEqual(expected, ret_val)
 
+    # VirtualRouter with nexthop_type=None StaticRoute child
+    def test_element_str_from_virtualrouter_with_sr_none(self):
+        """StaticRoute > VirtualRouter"""
+        expected = b"".join(
+            [
+                b'<entry name="default"><interface><member>ethernet1/3</member>',
+                b"</interface><routing-table><ip><static-route>",
+                b'<entry name="my none route"><destination>3.3.3.3/32',
+                b"</destination>",
+                b"<interface>ethernet1/4</interface><metric>10</metric>",
+                b"</entry></static-route></ip></routing-table></entry>",
+            ]
+        )
+
+        vro = panos.network.VirtualRouter("default", "ethernet1/3")
+        sro = panos.network.StaticRoute(
+            "my none route", "3.3.3.3/32", None, None, "ethernet1/4"
+        )
+
+        vro.add(sro)
+
+        ret_val = vro.element_str()
+
+        self.assertEqual(expected, ret_val)
+
+    # VirtualRouter with nexthop_type 'none' StaticRoute child
+    def test_element_str_from_virtualrouter_with_sr_none_str(self):
+        """StaticRoute > VirtualRouter"""
+        expected = b"".join(
+            [
+                b'<entry name="default"><interface><member>ethernet1/3</member>',
+                b"</interface><routing-table><ip><static-route>",
+                b'<entry name="my none route"><destination>3.3.3.3/32',
+                b"</destination>",
+                b"<interface>ethernet1/4</interface><metric>10</metric>",
+                b"</entry></static-route></ip></routing-table></entry>",
+            ]
+        )
+
+        vro = panos.network.VirtualRouter("default", "ethernet1/3")
+        sro = panos.network.StaticRoute(
+            "my none route", "3.3.3.3/32", "none", None, "ethernet1/4"
+        )
+
+        vro.add(sro)
+
+        ret_val = vro.element_str()
+
+        self.assertEqual(expected, ret_val)
+
     # 3) EthernetInterface
     def test_element_str_from_ethernetinterface(self):
         expected = b"".join(


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Add conditions to `StaticRoute` nexthop and nexthop_type params as well as accepting 'none' value as an input for nexthop_type.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Providing `None` vs a `'none'` string to `nexthop_type` param in `pan-os-ansible` panos_static_route module cause different behaviour. Providing `None` (meaning no value is provided) means to use the default value of the object on present/merged states whereas providing a `'none'` value means to set the nexthop_type to "None" in panos.

This is causing an issue with a recent change in pan-os-ansible where it fetches default values from pan-os-python sdk while creating or updating objects with None value params. With this change pan-os-python can also accept "none" str value for nexthop_type as well as structure the xml depending on the nexthop_type via conditions.

This is NOT a breaking change since it's still possible to use `StaticRoute` class with `nexthop_type` and `nexthop` set to `None` in order to produce "None" next hop type in panos xml.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested live on VMSeries firewalls as well as with the written integration tests.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
