### PR TITLE
fix: bgp peer properties are flipped

### DIFF
--- a/panos/network.py
+++ b/panos/network.py
@@ -3046,9 +3046,10 @@ class BgpPeerGroup(VersionedPanObject):
         )
         params.append(
             VersionedParamPath(
-                "export_nexthop",
-                path="type/{type}/export-nexthop",
-                values=("resolve", "use-self"),
+                "remove_private_as",
+                condition={"type": "ebgp"},
+                path="type/{type}/remove-private-as",
+                vartype="yesno",
             )
         )
         params.append(
@@ -3061,10 +3062,9 @@ class BgpPeerGroup(VersionedPanObject):
         )
         params.append(
             VersionedParamPath(
-                "remove_private_as",
-                condition={"type": "ebgp"},
-                path="type/{type}/remove-private-as",
-                vartype="yesno",
+                "export_nexthop",
+                path="type/{type}/export-nexthop",
+                values=("resolve", "use-self"),
             )
         )
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Reorder the peer-group properties. 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
We see that the order of BGP peer-group properties is important, otherwise the FW/Panorama will think there is a config change. By fixing the order same as how PANOS expects, there will be no additional commit required, if there is no change in BGP peer-group.

```
an_cfg_engine_execute_request(pan_cfg_engine.c:4560): set: Before str_len 5080, str: <virtual-router>
  <entry name="Main-Router">
    ...................
        <peer-group>
          <entry name="Prisma">
            <type>
              <ebgp>
                <remove-private-as>yes</remove-private-as>
                <import-nexthop>original</import-nexthop>
                <export-nexthop>resolve</export-nexthop>
              </ebgp>
            </type>
            <peer>

pan_cfg_engine_execute_request(pan_cfg_engine.c:4610): set: After str_len 5376, str: <virtual-router>
  <entry name="Main-Router">
      ............................
        <peer-group>
          <entry name="Prisma">
            <type>
              <ebgp>
                <export-nexthop>resolve</export-nexthop>
                <import-nexthop>original</import-nexthop>
                <remove-private-as>yes</remove-private-as>
              </ebgp>
            </type>
            <peer>
```
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. --> 
1. Configure Peergroup 
  `       BgpPeerGroup(name="pg-test", enable=True, aggregated_confed_as_path=True, soft_reset_with_stored_info=False, type="ebgp", remove_private_as=True, import_nexthop="original", export_nexthop="resolve")`
2. Commit the changes
3. Try to change any other config like adding a static route
4.  Without fix,  PANOS thinks there is a change in config due to incorrect order of parameters.
      With fix, We dont see any such config change request

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [x ] I have added tests to cover my changes if appropriate.
- [ x] All new and existing tests passed.
