### PR TITLE
Fix method signature mismatch in Firewall subclass

### DIFF
--- a/panos/firewall.py
+++ b/panos/firewall.py
@@ -280,7 +280,7 @@ class Firewall(PanDevice):
         self.content_version = system_info["system"]["app-version"]
         self.multi_vsys = system_info["system"]["multi-vsys"] == "on"
 
-    def element(self):
+    def element(self, with_children=True, comparable=False):
         if self.serial is None:
             raise ValueError("Serial number must be set to generate element")
         entry = ET.Element("entry", {"name": self.serial})


### PR DESCRIPTION
## Description

Fix exception due to method signature mismatch.

## Motivation and Context

While using ansible at work last week I got an exception due to the Firewall.element() method not having the same method signature of the parent PanObject class. The PanObject.element() method has two optional kwargs that are used elsewhere. When a Firewall object was passed into one of those code paths that passed in one or both of the kwargs python thew an exception.

The kwargs are unused in the Firewall class and I'm unsure how those kwargs can be used.

## How Has This Been Tested?

We have this package vendored into our repo at work so I patched it for now with the same change.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
