### PR TITLE
Enable Commit with `force` without `partial`

### DIFF
--- a/panos/firewall.py
+++ b/panos/firewall.py
@@ -590,7 +590,7 @@ class FirewallCommit(object):
             self.admins,
             self.exclude_device_and_network,
             self.exclude_shared_objects,
-            self.exclude_policy_and_objects
+            self.exclude_policy_and_objects,
         ]
 
         return any(x for x in pp_list)

--- a/panos/panorama.py
+++ b/panos/panorama.py
@@ -989,7 +989,7 @@ class PanoramaCommit(object):
             self.log_collectors,
             self.log_collector_groups,
             self.exclude_device_and_network,
-            self.exclude_shared_objects
+            self.exclude_shared_objects,
         ]
 
         return any(x for x in pp_list)


### PR DESCRIPTION
## Description

Allow a `force` commit for the whole configuration, i.e., without `partial`.

## Motivation and Context

If you do `load config from` in PAN-OS, the system requires a `force` commit for the whole configuration. Attempting to do `force` with `partial` triggers an error. 

In the previous code version, setting `force` flag automatically makes a commit `partial` that I believe is wrong.

## How Has This Been Tested?

Tested in PAN-OS 11.x as part of the Ansible playbook.

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

[x] Bug fix (non-breaking change which fixes an issue)
[ ] New feature (non-breaking change which adds functionality)
[ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
