### PR TITLE
fix partial commit bug from 1.12.5

### DIFF
--- a/panos/firewall.py
+++ b/panos/firewall.py
@@ -621,7 +621,7 @@ class FirewallCommit(object):
                 ET.SubElement(partial, "shared-object").text = "excluded"
             if self.exclude_policy_and_objects:
                 ET.SubElement(partial, "policy-and-objects").text = "excluded"
-            fe.append(partial)
+            root.append(partial)
 
         if self.force:
             fe = ET.SubElement(root, "force")

--- a/panos/firewall.py
+++ b/panos/firewall.py
@@ -622,7 +622,7 @@ class FirewallCommit(object):
                 ET.SubElement(partial, "shared-object").text = "excluded"
             if self.exclude_policy_and_objects:
                 ET.SubElement(partial, "policy-and-objects").text = "excluded"
-            fe.append(partial)
+            root.append(partial)
 
         if self.force:
             fe = ET.SubElement(root, "force")


### PR DESCRIPTION
## Description

[Previous change](https://github.com/PaloAltoNetworks/pan-os-python/commit/b4b84369d8fc8ab5b069d43d5ef77687bc9bd20f#diff-06294252b451e95b9fb84f65e07f92a5b12ac2f43c09bb5ca2d1570118dfc37eR624) incorrectly used `fe` before it is defined. Should be appending to root.

## Motivation and Context
Seeing errors when running partial commits, stems from changes from 1.12.5

## How Has This Been Tested?
Currently patching local systems with this change for partial commits to succeed

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
