### PR TITLE
fix: replace distutils.version.LooseVersion for Python 3.12+ compatibility

### DIFF
--- a/panos/__init__.py
+++ b/panos/__init__.py
@@ -32,7 +32,7 @@ __version__ = "1.12.1"
 import logging
 import sys
 import xml.etree.ElementTree as ET
-from distutils.version import LooseVersion  # Used by PanOSVersion class
+import re
 
 # Warn if running on end-of-life python
 if sys.version_info < (3, 6):
@@ -127,7 +127,28 @@ pan.DEBUG2 = pan.DEBUG1 - 1
 pan.DEBUG3 = pan.DEBUG2 - 1
 
 
-class PanOSVersion(LooseVersion):
+class _LooseVersion:
+    """Minimal LooseVersion replacement; distutils was removed in Python 3.12."""
+
+    _component_re = re.compile(r"(\d+|[a-z]+|\.)")
+
+    def __init__(self, vstring=None):
+        if vstring:
+            self.parse(vstring)
+
+    def parse(self, vstring):
+        self.vstring = vstring
+        parts = [x for x in self._component_re.split(vstring) if x and x != "."]
+        self.version = [int(x) if x.isdigit() else x for x in parts]
+
+    def __str__(self):
+        return self.vstring
+
+    def __repr__(self):
+        return "LooseVersion ('%s')" % str(self)
+
+
+class PanOSVersion(_LooseVersion):
     """LooseVersion with convenience properties to access version components"""
 
     @property


### PR DESCRIPTION
## Problem

`distutils` was deprecated in Python 3.10 and **removed entirely in Python 3.12**, making the library completely unusable on any modern Python installation:

```
ModuleNotFoundError: No module named 'distutils'
```

Fixes #580.

## Why not `pip install setuptools`?

The common workaround is adding `setuptools` as a runtime dependency, because setuptools ships its own `distutils` copy. This has two problems:

1. **It's the wrong tool for the job.** `setuptools` is a build-time dependency. Pulling it in at runtime just to recover 40 lines of version-parsing code couples every user's environment to a build tool they may not otherwise need.
2. **It breaks CI/CD silently.** Users running clean virtual environments (Docker images, GitHub Actions runners, etc.) hit the `ModuleNotFoundError` at import time with no clear signal that `setuptools` is required, since it isn't listed in the package's install dependencies.

## Why not the `packaging` library?

`packaging.version.Version` is the modern, maintained replacement for `distutils.version` — but it enforces **PEP 440**. PAN-OS version strings like `10.1.3-h3`, `9.0.0-b5`, and `11.0.0-c1` are not PEP 440-compliant (`h` is not a recognised pre-release identifier), so `packaging.version.Version` raises `InvalidVersion` on them. `packaging.version.LegacyVersion`, which did handle arbitrary strings, was removed in `packaging` 22.0 (2022).

## What this PR does

Inlines a minimal `_LooseVersion` class using only stdlib `re`. It replicates the exact parsing behaviour that `PanOSVersion` depends on:

- `10.1.3-h3` → `[10, 1, 3, '-', 'h', 3]`
- `9.0.0-b5`  → `[9, 0, 0, '-', 'b', 5]`
- `11.0.0`    → `[11, 0, 0]`

`PanOSVersion` already overrides every comparison operator (`__lt__`, `__gt__`, `__eq__`, `__le__`, `__ge__`, `__ne__`), so the only things inherited from `LooseVersion` were the parser and `__str__`. Both are reproduced exactly. No new dependencies are introduced.

## Testing

All 244 existing tests in `test_init.py`, `test_PanOScomp.py`, and `test_updater.py` pass unchanged on Python 3.14.