### PR TITLE
Fix security policy partial commit

### DIFF
--- a/panos/base.py
+++ b/panos/base.py
@@ -670,17 +670,19 @@ class PanObject(object):
         )
         device.set_config_changed()
         # For entry/member objects, use edit() against the entry's own xpath rather than
-        # set() against the parent container xpath. PAN-OS records edit() on an entry xpath
-        # as a CREATE owned by the calling admin; set() against the parent container is
-        # recorded as an EDIT on the container and changes admin lock ownership to the
-        # calling admin, which breaks partial commits for other admins.
+        # For entry/member objects, use set() against the entry's own xpath rather than
+        # the parent container xpath. PAN-OS records set() on an entry xpath as a CREATE
+        # owned by the calling admin. Using the parent container xpath is recorded as an
+        # EDIT on the container and changes admin lock ownership, breaking partial commits
+        # for other admins. xapi.edit() cannot be used here because PAN-OS rejects edit()
+        # on a non-existent entry — only set() creates new entries reliably.
         if self.SUFFIX in (ENTRY, MEMBER):
             if self.HA_SYNC:
-                device.active().xapi.edit(
+                device.active().xapi.set(
                     self.xpath(), self.element_str(), retry_on_peer=self.HA_SYNC
                 )
             else:
-                device.xapi.edit(
+                device.xapi.set(
                     self.xpath(), self.element_str(), retry_on_peer=self.HA_SYNC
                 )
         else:

--- a/panos/base.py
+++ b/panos/base.py
@@ -556,6 +556,19 @@ class PanObject(object):
             return parsed.toprettyxml(indent="\t", encoding="utf-8")
         return ET.tostring(self.element(), encoding="utf-8")
 
+    def element_str_inner(self):
+        """XML of this object's child elements only, without the root entry/member wrapper.
+
+        Used by create() when issuing set() against the entry's own xpath. PAN-OS
+        expects inner content only at that xpath — passing the full <entry> wrapper
+        causes a schema error ("may need to override template object first").
+
+        Returns:
+            bytes: concatenated XML of child elements, empty bytes if none.
+        """
+        root = self.element()
+        return b"".join(ET.tostring(child) for child in root)
+
     def _root_element(self):
         if self.SUFFIX == ENTRY:
             return ET.Element("entry", {"name": self.uid})
@@ -672,18 +685,20 @@ class PanObject(object):
         # For entry/member objects, use edit() against the entry's own xpath rather than
         # For entry/member objects, use set() against the entry's own xpath rather than
         # the parent container xpath. PAN-OS records set() on an entry xpath as a CREATE
-        # owned by the calling admin. Using the parent container xpath is recorded as an
-        # EDIT on the container and changes admin lock ownership, breaking partial commits
-        # for other admins. xapi.edit() cannot be used here because PAN-OS rejects edit()
-        # on a non-existent entry — only set() creates new entries reliably.
+        # For entry/member objects, use set() against the entry's own xpath with inner
+        # content only (no <entry> wrapper). PAN-OS records this as a CREATE owned by
+        # the calling admin. Using the parent container xpath is recorded as an EDIT on
+        # the container and changes admin lock ownership, breaking partial commits for
+        # other admins. Passing the full <entry> wrapper at the entry xpath causes a
+        # PAN-OS schema error ("may need to override template object first").
         if self.SUFFIX in (ENTRY, MEMBER):
             if self.HA_SYNC:
                 device.active().xapi.set(
-                    self.xpath(), self.element_str(), retry_on_peer=self.HA_SYNC
+                    self.xpath(), self.element_str_inner(), retry_on_peer=self.HA_SYNC
                 )
             else:
                 device.xapi.set(
-                    self.xpath(), self.element_str(), retry_on_peer=self.HA_SYNC
+                    self.xpath(), self.element_str_inner(), retry_on_peer=self.HA_SYNC
                 )
         else:
             if self.HA_SYNC:

--- a/panos/base.py
+++ b/panos/base.py
@@ -556,6 +556,23 @@ class PanObject(object):
             return parsed.toprettyxml(indent="\t", encoding="utf-8")
         return ET.tostring(self.element(), encoding="utf-8")
 
+    def element_str_inner(self):
+        """The XML of this object's children only, without the root entry/member wrapper.
+
+        Used by create() to issue a set call against the entry's own xpath rather than
+        the parent container xpath. This matches how the GUI writes config: target the
+        entry directly with its inner content so that PAN-OS records a CREATE on the
+        entry instead of an EDIT on the parent container (which would change admin lock
+        ownership to the calling admin).
+
+        Returns:
+            str: XML of the child elements as a concatenated byte string, or an empty
+                 byte string if the root has no children.
+
+        """
+        root = self.element()
+        return b"".join(ET.tostring(child, encoding="utf-8") for child in root)
+
     def _root_element(self):
         if self.SUFFIX == ENTRY:
             return ET.Element("entry", {"name": self.uid})
@@ -669,13 +686,20 @@ class PanObject(object):
             device.id + ': create called on %s object "%s"' % (type(self), self.uid)
         )
         device.set_config_changed()
-        element = self.element_str()
-        if self.HA_SYNC:
-            device.active().xapi.set(
-                self.xpath_short(), element, retry_on_peer=self.HA_SYNC
-            )
+        # For entry/member objects, target the entry's own xpath with inner content only.
+        # This matches how the GUI writes config: PAN-OS records a CREATE on the entry
+        # rather than an EDIT on the parent container, which would change admin lock
+        # ownership to the calling admin.
+        if self.SUFFIX in (ENTRY, MEMBER):
+            xpath = self.xpath()
+            element = self.element_str_inner()
         else:
-            device.xapi.set(self.xpath_short(), element, retry_on_peer=self.HA_SYNC)
+            xpath = self.xpath_short()
+            element = self.element_str()
+        if self.HA_SYNC:
+            device.active().xapi.set(xpath, element, retry_on_peer=self.HA_SYNC)
+        else:
+            device.xapi.set(xpath, element, retry_on_peer=self.HA_SYNC)
         for child in self.children:
             child._check_child_methods("create")
 

--- a/panos/base.py
+++ b/panos/base.py
@@ -556,23 +556,6 @@ class PanObject(object):
             return parsed.toprettyxml(indent="\t", encoding="utf-8")
         return ET.tostring(self.element(), encoding="utf-8")
 
-    def element_str_inner(self):
-        """The XML of this object's children only, without the root entry/member wrapper.
-
-        Used by create() to issue a set call against the entry's own xpath rather than
-        the parent container xpath. This matches how the GUI writes config: target the
-        entry directly with its inner content so that PAN-OS records a CREATE on the
-        entry instead of an EDIT on the parent container (which would change admin lock
-        ownership to the calling admin).
-
-        Returns:
-            str: XML of the child elements as a concatenated byte string, or an empty
-                 byte string if the root has no children.
-
-        """
-        root = self.element()
-        return b"".join(ET.tostring(child, encoding="utf-8") for child in root)
-
     def _root_element(self):
         if self.SUFFIX == ENTRY:
             return ET.Element("entry", {"name": self.uid})
@@ -686,20 +669,29 @@ class PanObject(object):
             device.id + ': create called on %s object "%s"' % (type(self), self.uid)
         )
         device.set_config_changed()
-        # For entry/member objects, target the entry's own xpath with inner content only.
-        # This matches how the GUI writes config: PAN-OS records a CREATE on the entry
-        # rather than an EDIT on the parent container, which would change admin lock
-        # ownership to the calling admin.
+        # For entry/member objects, use edit() against the entry's own xpath rather than
+        # set() against the parent container xpath. PAN-OS records edit() on an entry xpath
+        # as a CREATE owned by the calling admin; set() against the parent container is
+        # recorded as an EDIT on the container and changes admin lock ownership to the
+        # calling admin, which breaks partial commits for other admins.
         if self.SUFFIX in (ENTRY, MEMBER):
-            xpath = self.xpath()
-            element = self.element_str_inner()
+            if self.HA_SYNC:
+                device.active().xapi.edit(
+                    self.xpath(), self.element_str(), retry_on_peer=self.HA_SYNC
+                )
+            else:
+                device.xapi.edit(
+                    self.xpath(), self.element_str(), retry_on_peer=self.HA_SYNC
+                )
         else:
-            xpath = self.xpath_short()
-            element = self.element_str()
-        if self.HA_SYNC:
-            device.active().xapi.set(xpath, element, retry_on_peer=self.HA_SYNC)
-        else:
-            device.xapi.set(xpath, element, retry_on_peer=self.HA_SYNC)
+            if self.HA_SYNC:
+                device.active().xapi.set(
+                    self.xpath_short(), self.element_str(), retry_on_peer=self.HA_SYNC
+                )
+            else:
+                device.xapi.set(
+                    self.xpath_short(), self.element_str(), retry_on_peer=self.HA_SYNC
+                )
         for child in self.children:
             child._check_child_methods("create")
 

--- a/panos/firewall.py
+++ b/panos/firewall.py
@@ -622,7 +622,7 @@ class FirewallCommit(object):
                 ET.SubElement(partial, "shared-object").text = "excluded"
             if self.exclude_policy_and_objects:
                 ET.SubElement(partial, "policy-and-objects").text = "excluded"
-            fe.append(partial)
+            root.append(partial)
 
         if self.force:
             fe = ET.SubElement(root, "force")

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -584,13 +584,13 @@ class TestPanObject(unittest.TestCase):
             c._check_child_methods.assert_called_once_with("create")
 
     @mock.patch("panos.base.PanObject.uid", new_callable=mock.PropertyMock)
-    def test_create_entry_suffix_uses_entry_xpath_and_inner_element(self, m_uid):
-        # ENTRY-suffix objects must use self.xpath() (not xpath_short()) and
-        # element_str_inner() (not element_str()) so that PAN-OS records a CREATE
-        # on the entry itself rather than an EDIT on the parent container.
+    def test_create_entry_suffix_uses_edit_on_entry_xpath(self, m_uid):
+        # ENTRY-suffix objects must use xapi.edit() against the entry's own xpath so
+        # that PAN-OS records a CREATE on the entry rather than an EDIT on the parent
+        # container (which would change admin lock ownership to the calling admin).
         PanDeviceId = "42"
         PanDeviceXpath = "path/to/entry"
-        PanDeviceInnerElement = b"<from>any</from>"
+        PanDeviceElementStr = "element string"
 
         self.obj.SUFFIX = Base.ENTRY
 
@@ -598,26 +598,26 @@ class TestPanObject(unittest.TestCase):
         m_panos = mock.Mock(**spec)
         self.obj.nearest_pandevice = mock.Mock(return_value=m_panos)
         self.obj.xpath = mock.Mock(return_value=PanDeviceXpath)
-        self.obj.element_str_inner = mock.Mock(return_value=PanDeviceInnerElement)
+        self.obj.element_str = mock.Mock(return_value=PanDeviceElementStr)
         m_uid.return_value = "uid"
 
         ret_val = self.obj.create()
 
         self.assertIsNone(ret_val)
         m_panos.set_config_changed.assert_called_once_with()
-        m_panos.active().xapi.set.assert_called_once_with(
+        m_panos.active().xapi.edit.assert_called_once_with(
             PanDeviceXpath,
-            PanDeviceInnerElement,
+            PanDeviceElementStr,
             retry_on_peer=self.obj.HA_SYNC,
         )
         self.obj.xpath.assert_called_once_with()
-        self.obj.element_str_inner.assert_called_once_with()
+        self.obj.element_str.assert_called_once_with()
 
     @mock.patch("panos.base.PanObject.uid", new_callable=mock.PropertyMock)
     def test_create_entry_suffix_without_ha_sync(self, m_uid):
         PanDeviceId = "42"
         PanDeviceXpath = "path/to/entry"
-        PanDeviceInnerElement = b"<from>any</from>"
+        PanDeviceElementStr = "element string"
 
         self.obj.SUFFIX = Base.ENTRY
         self.obj.HA_SYNC = False
@@ -626,20 +626,20 @@ class TestPanObject(unittest.TestCase):
         m_panos = mock.Mock(**spec)
         self.obj.nearest_pandevice = mock.Mock(return_value=m_panos)
         self.obj.xpath = mock.Mock(return_value=PanDeviceXpath)
-        self.obj.element_str_inner = mock.Mock(return_value=PanDeviceInnerElement)
+        self.obj.element_str = mock.Mock(return_value=PanDeviceElementStr)
         m_uid.return_value = "uid"
 
         ret_val = self.obj.create()
 
         self.assertIsNone(ret_val)
         m_panos.set_config_changed.assert_called_once_with()
-        m_panos.xapi.set.assert_called_once_with(
+        m_panos.xapi.edit.assert_called_once_with(
             PanDeviceXpath,
-            PanDeviceInnerElement,
+            PanDeviceElementStr,
             retry_on_peer=self.obj.HA_SYNC,
         )
         self.obj.xpath.assert_called_once_with()
-        self.obj.element_str_inner.assert_called_once_with()
+        self.obj.element_str.assert_called_once_with()
 
     @mock.patch("panos.base.PanObject.uid", new_callable=mock.PropertyMock)
     def test_delete_with_ha_sync_no_parent(self, m_uid):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -584,14 +584,14 @@ class TestPanObject(unittest.TestCase):
             c._check_child_methods.assert_called_once_with("create")
 
     @mock.patch("panos.base.PanObject.uid", new_callable=mock.PropertyMock)
-    def test_create_entry_suffix_uses_set_on_entry_xpath(self, m_uid):
-        # ENTRY-suffix objects must use xapi.set() against the entry's own xpath (not
-        # the parent container xpath) so that PAN-OS records a CREATE on the entry
-        # rather than an EDIT on the parent container, which would change admin lock
-        # ownership to the calling admin and break partial commits for others.
+    def test_create_entry_suffix_uses_set_on_entry_xpath_with_inner_element(self, m_uid):
+        # ENTRY-suffix objects must use xapi.set() against the entry's own xpath with
+        # inner content only (no <entry> wrapper). Passing the full element_str() at
+        # the entry xpath causes PAN-OS schema error; using parent xpath causes an EDIT
+        # on the container changing admin lock ownership and breaking partial commits.
         PanDeviceId = "42"
         PanDeviceXpath = "path/to/entry"
-        PanDeviceElementStr = "element string"
+        PanDeviceInnerElement = b"<from>any</from>"
 
         self.obj.SUFFIX = Base.ENTRY
 
@@ -599,7 +599,7 @@ class TestPanObject(unittest.TestCase):
         m_panos = mock.Mock(**spec)
         self.obj.nearest_pandevice = mock.Mock(return_value=m_panos)
         self.obj.xpath = mock.Mock(return_value=PanDeviceXpath)
-        self.obj.element_str = mock.Mock(return_value=PanDeviceElementStr)
+        self.obj.element_str_inner = mock.Mock(return_value=PanDeviceInnerElement)
         m_uid.return_value = "uid"
 
         ret_val = self.obj.create()
@@ -608,17 +608,17 @@ class TestPanObject(unittest.TestCase):
         m_panos.set_config_changed.assert_called_once_with()
         m_panos.active().xapi.set.assert_called_once_with(
             PanDeviceXpath,
-            PanDeviceElementStr,
+            PanDeviceInnerElement,
             retry_on_peer=self.obj.HA_SYNC,
         )
         self.obj.xpath.assert_called_once_with()
-        self.obj.element_str.assert_called_once_with()
+        self.obj.element_str_inner.assert_called_once_with()
 
     @mock.patch("panos.base.PanObject.uid", new_callable=mock.PropertyMock)
     def test_create_entry_suffix_without_ha_sync(self, m_uid):
         PanDeviceId = "42"
         PanDeviceXpath = "path/to/entry"
-        PanDeviceElementStr = "element string"
+        PanDeviceInnerElement = b"<from>any</from>"
 
         self.obj.SUFFIX = Base.ENTRY
         self.obj.HA_SYNC = False
@@ -627,7 +627,7 @@ class TestPanObject(unittest.TestCase):
         m_panos = mock.Mock(**spec)
         self.obj.nearest_pandevice = mock.Mock(return_value=m_panos)
         self.obj.xpath = mock.Mock(return_value=PanDeviceXpath)
-        self.obj.element_str = mock.Mock(return_value=PanDeviceElementStr)
+        self.obj.element_str_inner = mock.Mock(return_value=PanDeviceInnerElement)
         m_uid.return_value = "uid"
 
         ret_val = self.obj.create()
@@ -636,11 +636,11 @@ class TestPanObject(unittest.TestCase):
         m_panos.set_config_changed.assert_called_once_with()
         m_panos.xapi.set.assert_called_once_with(
             PanDeviceXpath,
-            PanDeviceElementStr,
+            PanDeviceInnerElement,
             retry_on_peer=self.obj.HA_SYNC,
         )
         self.obj.xpath.assert_called_once_with()
-        self.obj.element_str.assert_called_once_with()
+        self.obj.element_str_inner.assert_called_once_with()
 
     @mock.patch("panos.base.PanObject.uid", new_callable=mock.PropertyMock)
     def test_delete_with_ha_sync_no_parent(self, m_uid):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -584,10 +584,11 @@ class TestPanObject(unittest.TestCase):
             c._check_child_methods.assert_called_once_with("create")
 
     @mock.patch("panos.base.PanObject.uid", new_callable=mock.PropertyMock)
-    def test_create_entry_suffix_uses_edit_on_entry_xpath(self, m_uid):
-        # ENTRY-suffix objects must use xapi.edit() against the entry's own xpath so
-        # that PAN-OS records a CREATE on the entry rather than an EDIT on the parent
-        # container (which would change admin lock ownership to the calling admin).
+    def test_create_entry_suffix_uses_set_on_entry_xpath(self, m_uid):
+        # ENTRY-suffix objects must use xapi.set() against the entry's own xpath (not
+        # the parent container xpath) so that PAN-OS records a CREATE on the entry
+        # rather than an EDIT on the parent container, which would change admin lock
+        # ownership to the calling admin and break partial commits for others.
         PanDeviceId = "42"
         PanDeviceXpath = "path/to/entry"
         PanDeviceElementStr = "element string"
@@ -605,7 +606,7 @@ class TestPanObject(unittest.TestCase):
 
         self.assertIsNone(ret_val)
         m_panos.set_config_changed.assert_called_once_with()
-        m_panos.active().xapi.edit.assert_called_once_with(
+        m_panos.active().xapi.set.assert_called_once_with(
             PanDeviceXpath,
             PanDeviceElementStr,
             retry_on_peer=self.obj.HA_SYNC,
@@ -633,7 +634,7 @@ class TestPanObject(unittest.TestCase):
 
         self.assertIsNone(ret_val)
         m_panos.set_config_changed.assert_called_once_with()
-        m_panos.xapi.edit.assert_called_once_with(
+        m_panos.xapi.set.assert_called_once_with(
             PanDeviceXpath,
             PanDeviceElementStr,
             retry_on_peer=self.obj.HA_SYNC,

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -584,6 +584,64 @@ class TestPanObject(unittest.TestCase):
             c._check_child_methods.assert_called_once_with("create")
 
     @mock.patch("panos.base.PanObject.uid", new_callable=mock.PropertyMock)
+    def test_create_entry_suffix_uses_entry_xpath_and_inner_element(self, m_uid):
+        # ENTRY-suffix objects must use self.xpath() (not xpath_short()) and
+        # element_str_inner() (not element_str()) so that PAN-OS records a CREATE
+        # on the entry itself rather than an EDIT on the parent container.
+        PanDeviceId = "42"
+        PanDeviceXpath = "path/to/entry"
+        PanDeviceInnerElement = b"<from>any</from>"
+
+        self.obj.SUFFIX = Base.ENTRY
+
+        spec = {"id": PanDeviceId}
+        m_panos = mock.Mock(**spec)
+        self.obj.nearest_pandevice = mock.Mock(return_value=m_panos)
+        self.obj.xpath = mock.Mock(return_value=PanDeviceXpath)
+        self.obj.element_str_inner = mock.Mock(return_value=PanDeviceInnerElement)
+        m_uid.return_value = "uid"
+
+        ret_val = self.obj.create()
+
+        self.assertIsNone(ret_val)
+        m_panos.set_config_changed.assert_called_once_with()
+        m_panos.active().xapi.set.assert_called_once_with(
+            PanDeviceXpath,
+            PanDeviceInnerElement,
+            retry_on_peer=self.obj.HA_SYNC,
+        )
+        self.obj.xpath.assert_called_once_with()
+        self.obj.element_str_inner.assert_called_once_with()
+
+    @mock.patch("panos.base.PanObject.uid", new_callable=mock.PropertyMock)
+    def test_create_entry_suffix_without_ha_sync(self, m_uid):
+        PanDeviceId = "42"
+        PanDeviceXpath = "path/to/entry"
+        PanDeviceInnerElement = b"<from>any</from>"
+
+        self.obj.SUFFIX = Base.ENTRY
+        self.obj.HA_SYNC = False
+
+        spec = {"id": PanDeviceId}
+        m_panos = mock.Mock(**spec)
+        self.obj.nearest_pandevice = mock.Mock(return_value=m_panos)
+        self.obj.xpath = mock.Mock(return_value=PanDeviceXpath)
+        self.obj.element_str_inner = mock.Mock(return_value=PanDeviceInnerElement)
+        m_uid.return_value = "uid"
+
+        ret_val = self.obj.create()
+
+        self.assertIsNone(ret_val)
+        m_panos.set_config_changed.assert_called_once_with()
+        m_panos.xapi.set.assert_called_once_with(
+            PanDeviceXpath,
+            PanDeviceInnerElement,
+            retry_on_peer=self.obj.HA_SYNC,
+        )
+        self.obj.xpath.assert_called_once_with()
+        self.obj.element_str_inner.assert_called_once_with()
+
+    @mock.patch("panos.base.PanObject.uid", new_callable=mock.PropertyMock)
     def test_delete_with_ha_sync_no_parent(self, m_uid):
         PanDeviceId = "42"
         PanDeviceXpath = "path"


### PR DESCRIPTION
## Description

Fix partial candidate owner overwrite with paloaltonetworks.panos.panos_security_rule

## Motivation and Context

Fixes https://github.com/PaloAltoNetworks/pan-os-ansible/issues/642
Changes of https://github.com/PaloAltoNetworks/pan-os-python/pull/609 are implemented as well


## How Has This Been Tested?

Tested with `python3 -m pytest tests/test_base.py` and
```
python3 -c "
import sys
sys.path.insert(0, '.')
import panos.objects as obj
import panos.firewall as fw

# Create a firewall stub and an address object
from unittest import mock

# Test element_str_inner on an AddressObject (SUFFIX=ENTRY)
from panos.objects import AddressObject
a = AddressObject('test-host', value='10.0.0.1', type='ip-netmask', description='test')
print('element_str:', a.element_str())
print()
print('element_str_inner:', a.element_str_inner())
"
```

Additionally this was tested in a real Ansible playbook with the example results below.

## Examples

Before fix, first manual firwall rule change on PAN-OS GUI:

```
admin1@firewall(active)> show config list changes


xpath: /config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/rulebase/security/rules/entry[@name='partial test']
owner: admin1
action:  CREATE MOVE
other admins:admin1
dirty id:40
prev dirty id:0
replaydbIds:2232 2231
```

After applying security policies with paloaltonetworks.panos.panos_security_rule via Ansible:

```
admin1@firewall(active)> show config list changes


xpath: /config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/rulebase/security/rules
owner: admin2
action:  EDIT
other admins:admin2
dirty id:40
prev dirty id:0
replaydbIds:2233 2232 2231
```

The candidate config from two administrators got merged together, and could only be commited together.

Fixed code results in:

```
admin1@firewall(active)> show config list changes

xpath: /config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/rulebase/security/rules/entry[@name='test partial']
owner: admin1
action:  CREATE MOVE
other admins:admin1
dirty id:44
prev dirty id:0
replaydbIds:2249 2248

xpath: /config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/rulebase/security/rules/entry[@name='ssl_2_KINVO_K8S_CAPI_STG_AD']
owner: admin2
action:  CREATE
other admins:admin2
dirty id:44
prev dirty id:0
replaydbIds:2250
```

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
- This needs a fix in pan-os-ansible as well, see: https://github.com/PaloAltoNetworks/pan-os-ansible/pull/669

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [x ] I have added tests to cover my changes if appropriate.
- [x ] All new and existing tests passed.



fix_security_policy_partial_commit