### PR TITLE
fix(ha): clear stale ha_failed when refreshing HA active state

### DIFF
--- a/panos/base.py
+++ b/panos/base.py
@@ -4765,6 +4765,8 @@ class PanDevice(PanObject):
         else:
             for fw, state in ((self, self_state), (self.ha_peer, peer_state)):
                 fw._ha_active = state == "active"
+                # Reached this device for its state, so it is no longer failed.
+                fw.ha_failed = False
             return self_state
 
     def synchronize_config(self):

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -14,6 +14,12 @@
 
 import unittest
 
+# Python 2 has no unittest.mock; fall back to the standalone mock package.
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
 import panos
 import panos.firewall
 
@@ -49,6 +55,42 @@ class TestFirewall(unittest.TestCase):
         ret_val = fw.id
 
         self.assertEqual(expected, ret_val)
+
+
+class TestFirewallHa(unittest.TestCase):
+    def _ha_pair(self):
+        fw = panos.firewall.Firewall("10.0.0.1", "user", "pass")
+        peer = panos.firewall.Firewall("10.0.0.2", "user", "pass")
+        fw.set_ha_peers(peer)
+        return fw, peer
+
+    def test_refresh_ha_active_clears_stale_ha_failed(self):
+        """A live state refresh clears ha_failed on the reachable device."""
+        fw, peer = self._ha_pair()
+        # A transient error failed this device and promoted the peer to active.
+        fw.set_failed()
+        self.assertTrue(fw.ha_failed)
+        # Live HA now reports this device is active again.
+        fw.show_highavailability_state = mock.Mock(return_value=("active", None))
+        peer.show_highavailability_state = mock.Mock(return_value=("passive", None))
+
+        fw.refresh_ha_active()
+
+        self.assertFalse(fw.ha_failed)
+
+    def test_refresh_ha_active_keeps_ha_failed_when_state_not_authoritative(self):
+        """A non-authoritative state (initial/disabled) leaves ha_failed untouched."""
+        fw, peer = self._ha_pair()
+        # A transient error failed this device.
+        fw.set_failed()
+        self.assertTrue(fw.ha_failed)
+        # HA is still initializing, so the reported state is not authoritative.
+        fw.show_highavailability_state = mock.Mock(return_value=("initial", None))
+        peer.show_highavailability_state = mock.Mock(return_value=("active", None))
+
+        fw.refresh_ha_active()
+
+        self.assertTrue(fw.ha_failed)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`PanDevice.refresh_ha_active()` refreshes each device's `_ha_active` flag from
the live HA state, but it never clears `ha_failed`. A device that was marked
failed by a prior transient connection error (via `set_failed()`) therefore
stays "failed" even after it has recovered and is reachable again.

Because `XapiWrapper` routes API calls away from a device whose `ha_failed` is
`True` (to the HA peer), calls keep going to the peer indefinitely. In a
Panorama HA pair this means User-ID / config calls are sent to the **passive**
member, which silently never propagates them to the firewalls.

## Root cause

`refresh_ha_active()` only reaches its `else` branch after successfully reading
the live HA state from **both** devices (`show_highavailability_state()`). A
successful read proves the device is reachable, so `ha_failed` should be cleared
there — but the method only updated `_ha_active`, leaving the stale `ha_failed`
behind. There was no path (other than manual `dev.ha_failed = False` or
`set_failed()` on the peer) to recover routing.

## Fix

Clear `ha_failed` for each device whose live HA state was successfully read,
alongside the existing `_ha_active` update. Non-authoritative states
(`disabled` / `initial`) return early, so the flag is left untouched when the
state is not trustworthy.

```python
else:
    for fw, state in ((self, self_state), (self.ha_peer, peer_state)):
        fw._ha_active = state == "active"
        # Reached this device for its state, so it is no longer failed.
        fw.ha_failed = False
    return self_state
```

## Tests

Adds `TestFirewallHa` covering both paths:
- `test_refresh_ha_active_clears_stale_ha_failed` — a live refresh clears
  `ha_failed` on the reachable device.
- `test_refresh_ha_active_keeps_ha_failed_when_state_not_authoritative` — a
  non-authoritative (`initial` / `disabled`) state leaves `ha_failed` untouched.

## Compatibility

No API change. `refresh_ha_active()` keeps its signature and return value; it
just additionally clears the stale flag it was always meant to reconcile.
