### PR TITLE
fix: Fix regression in partial commits for FirewallCommit

### DIFF
--- a/panos/firewall.py
+++ b/panos/firewall.py
@@ -622,9 +622,9 @@ class FirewallCommit(object):
                 ET.SubElement(partial, "shared-object").text = "excluded"
             if self.exclude_policy_and_objects:
                 ET.SubElement(partial, "policy-and-objects").text = "excluded"
-            fe.append(partial)
+            root.append(partial)
 
         if self.force:
-            fe = ET.SubElement(root, "force")
+            ET.SubElement(root, "force")
 
         return root


### PR DESCRIPTION
fixes #612

tested using a simple script that implements a partial commit:

```
import os
from panos import firewall
from panos.firewall import FirewallCommit

if __name__ == '__main__':
    print("Committing to firewall")
    commit = FirewallCommit(
        description="test commit",
        exclude_shared_objects=True,
    )
    fw = firewall.Firewall("xxxxx", api_username="xxxx", api_password=os.getenv("PD_PASSWORD"))
    result = fw.commit(cmd=commit)
    print(result)
```

Partial commit works successfully:

```xml
<tenq>2026/07/21 16:46:45</tenq>
<tdeq>16:46:45</tdeq>
<id>3</id>
<user>xxx</user>
<type>Commit</type>
<status>FIN</status>
<queued>NO</queued>
<stoppable>no</stoppable>
<result>OK</result>
<tfin>2026/07/21 16:48:32</tfin>
<description>test commit</description>
<positionInQ>0</positionInQ>
<progress>100</progress>
<p2done>yes</p2done>
```